### PR TITLE
register proportion policy in factory

### DIFF
--- a/cmd/kube-arbitrator/app/options/options.go
+++ b/cmd/kube-arbitrator/app/options/options.go
@@ -17,6 +17,9 @@ limitations under the License.
 package options
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/spf13/pflag"
 
 	"github.com/kubernetes-incubator/kube-arbitrator/pkg/policy/proportion"
@@ -41,4 +44,13 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.Kubeconfig, "kubeconfig", s.Kubeconfig, "Path to kubeconfig file with authorization and master location information.")
 	// The default policy is Proportion policy.
 	fs.StringVar(&s.Policy, "policy", proportion.PolicyName, "The policy that used to allocate resources")
+}
+
+func (s *ServerOption) CheckOptionOrDie() {
+	switch s.Policy {
+	case proportion.PolicyName:
+	default:
+		fmt.Fprintf(os.Stderr, "invalid policy name %s\n", s.Policy)
+		os.Exit(1)
+	}
 }

--- a/cmd/kube-arbitrator/main.go
+++ b/cmd/kube-arbitrator/main.go
@@ -29,6 +29,7 @@ func main() {
 	s := options.NewServerOption()
 	s.AddFlags(pflag.CommandLine)
 	pflag.Parse()
+	s.CheckOptionOrDie()
 
 	if err := app.Run(s); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)

--- a/pkg/policy/factory.go
+++ b/pkg/policy/factory.go
@@ -16,10 +16,18 @@ limitations under the License.
 
 package policy
 
-import "sync"
+import (
+	"sync"
+
+	"github.com/kubernetes-incubator/kube-arbitrator/pkg/policy/proportion"
+)
 
 var policyMap = make(map[string]Interface)
 var mutex sync.Mutex
+
+func init() {
+	RegisterPolicy(proportion.PolicyName, proportion.New())
+}
 
 func New(name string) Interface {
 	mutex.Lock()

--- a/pkg/policy/proportion/proportion.go
+++ b/pkg/policy/proportion/proportion.go
@@ -20,7 +20,6 @@ import (
 	"github.com/golang/glog"
 
 	apiv1 "github.com/kubernetes-incubator/kube-arbitrator/pkg/apis/v1"
-	"github.com/kubernetes-incubator/kube-arbitrator/pkg/policy"
 	"github.com/kubernetes-incubator/kube-arbitrator/pkg/schedulercache"
 
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -30,11 +29,11 @@ import (
 // that need a name, e.g. default policy, register proportion policy.
 var PolicyName = "proportion"
 
-func init() {
-	policy.RegisterPolicy(PolicyName, &proportionScheduler{})
+type proportionScheduler struct {
 }
 
-type proportionScheduler struct {
+func New() *proportionScheduler {
+	return &proportionScheduler{}
 }
 
 func (ps *proportionScheduler) Name() string {


### PR DESCRIPTION
Currently, calling `init()` in proportion.go is triggered by following code in `cmd/kube-arbitrator/app/options/options.go`

```
import (
    "github.com/kubernetes-incubator/kube-arbitrator/pkg/policy/proportion"
)
```

this PR is to register proportion policy in policy factory to avoid the potential issue that `init()` in proportion.go is not called.