### PR TITLE
assign resource to queue

### DIFF
--- a/pkg/policy/preemption/preemption.go
+++ b/pkg/policy/preemption/preemption.go
@@ -396,12 +396,18 @@ func (p *basePreemption) PreemptResources(queues map[string]*schedulercache.Queu
 			}
 		}
 
+		// only update Queue Status Allocated/Deserved/Used/Preempting
+		oldQueue.Status.Allocated.Resources = q.Queue().Status.Allocated.Resources
+		oldQueue.Status.Deserved.Resources = q.Queue().Status.Deserved.Resources
+		oldQueue.Status.Used.Resources = q.Queue().Status.Used.Resources
+		oldQueue.Status.Preempting.Resources = q.Queue().Status.Preempting.Resources
+
 		result := apiv1.Queue{}
 		err = queueClient.Put().
 			Resource(apiv1.QueuePlural).
-			Namespace(q.Queue().Namespace).
-			Name(q.Queue().Name).
-			Body(q.Queue()).
+			Namespace(oldQueue.Namespace).
+			Name(oldQueue.Name).
+			Body(oldQueue.DeepCopy()).
 			Do().Into(&result)
 		if err != nil {
 			glog.Errorf("Fail to update queue info, name %s, %#v", q.Queue().Name, err)


### PR DESCRIPTION
When there is no taskset under a queue, kube-arbitrator will not assign resources to this queue even if it has resource request.

After this fix, kube-arbitrator will assign resources to a queue according to its weight and resource request even if there is no taskset under this queue.