### PR TITLE
fix race condition between cache and policy

### DIFF
--- a/pkg/controller/policy_controller.go
+++ b/pkg/controller/policy_controller.go
@@ -85,7 +85,7 @@ func (pc *PolicyController) Run(stopCh <-chan struct{}) {
 	go pc.cache.Run(stopCh)
 	pc.cache.WaitForCacheSync(stopCh)
 
-	go wait.Until(pc.runOnce, 2*time.Second, stopCh)
+	go wait.Until(pc.runOnce, 4*time.Second, stopCh)
 	go wait.Until(pc.processAllocDecision, 0, stopCh)
 }
 


### PR DESCRIPTION
There is a race condition between policy and cache, pod status in cache may be not consistent with last policy schedule result.

`podSetInfo` will go through Pending pods to calculate the assigned Pod number to reduce the frequency. However, the issue will not be fixed totally by this PR.

The following ways may fix this issue, need some investigation
* Policy will not start next schedule till it updates all scheduler result to api-server
* When policy assign resources, consider the last schedule result, policy needs to record the last scheduler result
