### PR TITLE
use NodeName assigned by policy instead of pod.Spec.NodeName

### DIFF
--- a/pkg/batchd/cache/cache.go
+++ b/pkg/batchd/cache/cache.go
@@ -273,7 +273,7 @@ func (sc *SchedulerCache) deletePod(pod *v1.Pod) error {
 	delete(sc.Pods, key)
 
 	if len(pi.NodeName) != 0 {
-		node := sc.Nodes[pod.Spec.NodeName]
+		node := sc.Nodes[pi.NodeName]
 		if node != nil {
 			node.RemovePod(pi)
 		}


### PR DESCRIPTION
Use NodeName assigned by policy instead of Pod.Spec.NodeName

Otherwise, scheduler cache will not delete assumed pod from a node.