### PR TITLE
gang scheduling for PodSet

### DIFF
--- a/pkg/batchd/policy/drf/podset_info.go
+++ b/pkg/batchd/policy/drf/podset_info.go
@@ -88,6 +88,23 @@ func (psi *podSetInfo) pushPendingPod(p *cache.PodInfo) {
 	psi.podSet.Pending = append(psi.podSet.Pending, p)
 }
 
+func (psi *podSetInfo) resetAndGetAssignedPod(name string) *cache.PodInfo {
+	for index, p := range psi.podSet.Pending {
+		if p.Name != name {
+			continue
+		}
+
+		if psi.pendingIndex > index {
+			psi.pendingIndex = index
+		}
+
+		p.NodeName = ""
+		return p.Clone()
+	}
+
+	return nil
+}
+
 func (psi *podSetInfo) meetMinAvailable() bool {
 	return len(psi.podSet.Running)+len(psi.podSet.Assigned) >= psi.podSet.MinAvailable
 }


### PR DESCRIPTION
The brief scheduling process for `minAvailable`:

1. Policy assign `minAvailable` for each PodSet first
2. If all PodSet get their `minAvailable` in step 1, then policy assign left resources to these PodSet by DRF. 
3. If some of PodSets could not get their `minAvailable` in step 1, the policy will not assign any resources to PodSet. The unassigned resources will be kept by policy.