### PR TITLE
RFC: Add a new option --scheduler-name for ignoring pods which should be h…

### DIFF
--- a/cmd/kube-batchd/app/options/options.go
+++ b/cmd/kube-batchd/app/options/options.go
@@ -22,9 +22,10 @@ import (
 
 // ServerOption is the main context object for the controller manager.
 type ServerOption struct {
-	Master     string
-	Kubeconfig string
-	Policy     string
+	Master        string
+	Kubeconfig    string
+	Policy        string
+	SchedulerName string
 }
 
 // NewServerOption creates a new CMServer with a default config.
@@ -39,6 +40,8 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.Kubeconfig, "kubeconfig", s.Kubeconfig, "Path to kubeconfig file with authorization and master location information.")
 	// The default policy is Proportion policy.
 	fs.StringVar(&s.Policy, "policy", "drf", "The policy that used to allocate resources")
+	// kube-arbitrator will ignore pods with scheduler names other than specified with the option
+	fs.StringVar(&s.SchedulerName, "scheduler-name", "default-scheduler", "kube-arbitrator will handle pods with the scheduler-name")
 }
 
 func (s *ServerOption) CheckOptionOrDie() {

--- a/cmd/kube-batchd/app/server.go
+++ b/cmd/kube-batchd/app/server.go
@@ -46,7 +46,7 @@ func Run(opt *options.ServerOption) error {
 	queueController.Run(neverStop)
 
 	// Start policy controller to allocate resources.
-	policyController, err := controller.NewPolicyController(config, opt.Policy)
+	policyController, err := controller.NewPolicyController(config, opt.Policy, opt.SchedulerName)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/batchd/controller/policy_controller.go
+++ b/pkg/batchd/controller/policy_controller.go
@@ -52,7 +52,7 @@ func podSetKey(obj interface{}) (string, error) {
 	return fmt.Sprintf("%s/%s", podSet.Namespace, podSet.Name), nil
 }
 
-func NewPolicyController(config *rest.Config, policyName string) (*PolicyController, error) {
+func NewPolicyController(config *rest.Config, policyName string, schedulerName string) (*PolicyController, error) {
 	cs, err := clientset.NewForConfig(config)
 	if err != nil {
 		return nil, fmt.Errorf("fail to create client for PolicyController: %#v", err)
@@ -72,7 +72,7 @@ func NewPolicyController(config *rest.Config, policyName string) (*PolicyControl
 		config:     config,
 		clientset:  cs,
 		kubeclient: kc,
-		cache:      schedcache.New(config),
+		cache:      schedcache.New(config, schedulerName),
 		allocator:  alloc,
 		podSets:    cache.NewFIFO(podSetKey),
 	}


### PR DESCRIPTION
…andled by the default scheduler

This commit adds a new option --scheduler-name to
kube-batchd. kube-batchd handles pods which have the name specified
with the option in its v1.Pod.Spec.SchedulerName. The motivation is
separating pods which should be controlled by kube-batchd from other
pods which can be handled by the default scheduler.

I'm still not fully sure this change is valuable for kube-arbitrator's design. If I can have comments, I'm really glad.