### PR TITLE
<design docs> Minor fixes: MarkDown formatting, typos

### DIFF
--- a/doc/design/preemption.md
+++ b/doc/design/preemption.md
@@ -1,11 +1,11 @@
-#Preemption design behaviour
+# Preemption design behaviour
 
 @jinzhejz, 12/13/2017
 
-##Overview
+## Overview
 The document shows detail behaviour of preemption.
 
-##API
+## API
 ```go
 type Interface interface {
 	Run(stopCh <-chan struct{})
@@ -22,7 +22,7 @@ A preemptor providers three interfaces, `Run()`,`Preprocessing()` and `PreemptRe
 * `Preprocessing()` to preprocess queues, make sure `Allocated < Used` in each queue.
 * `PreemptResources()` to preempt resources between different queues.
 
-###Preprocess stage
+### Preprocess stage
 Currently, this stage terminates pods of the queue which `Allocated < Used` to avoid overuse(make queue `Allocated >= Used`), preemption will not be triggered between queues.
 
 ```
@@ -59,7 +59,7 @@ However, Queue-1 is overused due to some race condition. So pod-1 will be chosen
 --------------------------------------------------------------------------
 ```
 
-###Preemption stage
+### Preemption stage
 Preempt resources between queues. This stage will divide all queues into three categories:
 
 * Case-01 : `Deserved < Allocated`
@@ -229,7 +229,7 @@ After pod-3 in Queue-1 and pod-3 in Queue-2 are terminated, Queue-3 resources wi
 
 ```
 
-##Future work
+## Future work
 * In preprogress and preemption stage, the pod will be chosen randomly to kill. This may cause some more important pods killed. To solve this case, the following strategy  can be used to choose pod
 	* Priority. Each pod has a priority, the lower priority pod will be selected first.
 	* Status. The pending pod will be selected first and then running pod will be selected.

--- a/doc/design/queue_api.md
+++ b/doc/design/queue_api.md
@@ -9,7 +9,7 @@
 [Resource sharing architecture for batch and serving workloads in Kubernetes](https://docs.google.com/document/d/1-H2hnZap7gQivcSU-9j4ZrJ8wE_WwcfOkTeAGjzUyLA/edit#) proposed
 `QueueJob` feature to run batch job with services workload in Kuberentes. Considering the complexity, the 
 whole batch job proposal was seperated into two phase: `Queue` and `QueueJob`. This document 
-presents the API deinition of `Queue` for MVP.
+presents the API definition of `Queue` for MVP.
 
 ### Scope
 
@@ -81,7 +81,7 @@ Only Quota Manager can update Resource Quota. And it has two responsibility:
 
 ### Scheduler Cache
 
-Scheduler Cache periodically fetches all Node/Pod/Queue information in the cluster from API server. That inforamtion will only be stored in memory and not persisted on disk.
+Scheduler Cache periodically fetches all Node/Pod/Queue information in the cluster from API server. That information will only be stored in memory and not persisted on disk.
 
 It provides two interfaces `Run()` and `Dump()`
 
@@ -108,7 +108,7 @@ type Snapshot struct {
 
 ### Proportion Policy
 
-The policy summary usable resources(CPU and memory) on all nodes and allocate them to each Queue by `Weight` and `Request` in `QueueSpec` according to max-min weighted fairness algorithm. `Pods` is not used in the policy, it is for preemption in next step.
+The policy creates a summary of usable resources(CPU and memory) on all nodes and allocates them to each Queue by `Weight` and `Request` in `QueueSpec` according to max-min weighted fairness algorithm. `Pods` is not used in the policy, it is for preemption in next step.
 
 ```
 Snapshot information:

--- a/doc/design/queuejob_api.md
+++ b/doc/design/queuejob_api.md
@@ -1,12 +1,12 @@
-#QueueJob API
+# QueueJob API
 
 @jinzhejz, 12/22/2017
 
-##Overview
+## Overview
 [Resource sharing architecture for batch and serving workloads in Kubernetes](https://docs.google.com/document/d/1-H2hnZap7gQivcSU-9j4ZrJ8wE_WwcfOkTeAGjzUyLA/edit#) proposed
-`QueueJob` feature to run batch job with services workload in Kuberentes. Considering the complexity, the whole batch job proposal was seperated into two phase: `Queue` and `QueueJob`. This document presents the API deinition of `QueueJob` and feature interaction with `Queue`.
+`QueueJob` feature to run batch job with services workload in Kuberentes. Considering the complexity, the whole batch job proposal was seperated into two phase: `Queue` and `QueueJob`. This document presents the API definition of `QueueJob` and feature interaction with `Queue`.
 
-##API
+## API
 ```go
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type QueueJob struct {
@@ -39,8 +39,8 @@ type QueueJobList struct {
 }
 ```
 
-##Function details
-###Workflow
+## Function details
+### Workflow
 ![workflow](../images/queuejob.jpg)
 
 It is basically the same as the workflow in Queue API document (`QuotaManager` is not included in above workflow). The difference is just including `QueueJob` in `Queue`.
@@ -53,5 +53,5 @@ A `Queue` can include 0 or more `QueueJob`.
 For Queue `q01` and `q02`, Kube-arbitrator will assign resources to their QueueJob directly.
 For Queue `q03`, Kube-arbitrator will just assign resources to the Queue.
 
-##Future work
+## Future work
 * Now QueueJob is associated not with the real batch job, users who want to submit a batch job need to create their own QueueJob and watch the QueueJob, then submit their batch job after kube-arbitrator assign resources to QueueJob.


### PR DESCRIPTION
This PR fixes some minor errors in MarkDown formatting (#example -> # example), some typos and some grammatical mistakes in the design docs.