### PR TITLE
Enhance queuejob controller

### DIFF
--- a/pkg/batchd/controller/queuejob/sync_map.go
+++ b/pkg/batchd/controller/queuejob/sync_map.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queuejob
+
+import (
+	"fmt"
+	"sync"
+)
+
+type syncCounterMap struct {
+	sync.Mutex
+	m map[string]int
+}
+
+func newSyncCounterMap() *syncCounterMap {
+	return &syncCounterMap{
+		m: make(map[string]int),
+	}
+}
+
+func (sm *syncCounterMap) set(k string, v int) {
+	sm.Mutex.Lock()
+	defer sm.Mutex.Unlock()
+
+	sm.m[k] = v
+}
+
+func (sm *syncCounterMap) get(k string) (int, bool) {
+	sm.Mutex.Lock()
+	defer sm.Mutex.Unlock()
+
+	v, ok := sm.m[k]
+	return v, ok
+}
+
+func (sm *syncCounterMap) delete(k string) {
+	sm.Mutex.Lock()
+	defer sm.Mutex.Unlock()
+
+	delete(sm.m, k)
+}
+
+func (sm *syncCounterMap) decreaseCounter(k string) (int, error) {
+	sm.Mutex.Lock()
+	defer sm.Mutex.Unlock()
+
+	v, ok := sm.m[k]
+	if !ok {
+		return 0, fmt.Errorf("Fail to find counter for key %s", k)
+	}
+
+	if v > 0 {
+		v--
+	}
+
+	if v == 0 {
+		delete(sm.m, k)
+	} else {
+		sm.m[k] = v
+	}
+
+	return v, nil
+}

--- a/pkg/batchd/controller/queuejob/utils.go
+++ b/pkg/batchd/controller/queuejob/utils.go
@@ -20,9 +20,13 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
 
 	arbv1 "github.com/kubernetes-incubator/kube-arbitrator/pkg/batchd/apis/v1"
+	"github.com/kubernetes-incubator/kube-arbitrator/pkg/batchd/client"
 	uuid "github.com/satori/go.uuid"
 )
 
@@ -82,4 +86,16 @@ func buildPod(n, ns string, template corev1.PodTemplateSpec, owner []metav1.Owne
 		},
 		Spec: templateCopy.Spec,
 	}
+}
+
+func createQueueJobCRD(config *rest.Config) error {
+	extensionscs, err := apiextensionsclient.NewForConfig(config)
+	if err != nil {
+		return err
+	}
+	_, err = client.CreateQueueJobCRD(extensionscs)
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
Terminate all pods of a queuejob and re-create them for gang scheduling when below cases happen:

* a pod is termiated by system/user unexpectedly
* queuejob replicas is changed