### PR TITLE
docker images for kube-batchd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ generate-code:
 	${BIN_DIR}/deepcopy-gen -i ./pkg/batchd/apis/v1/ -O zz_generated.deepcopy
 	${BIN_DIR}/deepcopy-gen -i ./pkg/quotalloc/apis/v1/ -O zz_generated.deepcopy
 
+images: kube-arbitrator
+	cp ./_output/bin/kube-batchd ./deployment/
+	docker build ./deployment/ -t kubearbitrator/batchd:v0.1
+
 test-integration:
 	hack/make-rules/test-integration.sh $(WHAT)
 

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,0 +1,3 @@
+From ubuntu:18.04
+
+ADD kube-batchd /opt

--- a/deployment/kube-batchd.yaml
+++ b/deployment/kube-batchd.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    component: scheduler
+    tier: control-plane
+  name: kube-batchd
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        component: scheduler
+        tier: control-plane
+        version: second
+    spec:
+      containers:
+      - command:
+        - /bin/sh
+        - -c
+        - touch /tmp/healthy; /opt/kube-batchd --scheduler-name kube-batchd; rm -f /tmp/healthy
+        image: kubearbitrator/batchd:v0.1
+        livenessProbe:
+          exec:
+            command:
+            - cat
+            - /tmp/healthy
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        name: kube-second-scheduler
+        resources:
+          requests:
+            cpu: '0.1'
+        securityContext:
+          privileged: false
+        volumeMounts: []
+      hostNetwork: false
+      hostPID: false
+      volumes: []


### PR DESCRIPTION
This PR is for kube-batchd docker images, include:

* The official images is uploaded to https://hub.docker.com/r/kubearbitrator/batchd/
* The batchd_tutorial.md is updated for the new images
* Build images locally for developer