### PR TITLE
Adding coverage flag in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ images: kube-arbitrator
 run-test:
 	hack/make-rules/test.sh $(WHAT) $(TESTS)
 
+coverage:
+	KUBE_COVER=y hack/make-rules/test.sh $(WHAT) $(TESTS)
+
 clean:
 	rm -rf _output/
 	rm -f kube-arbitrator


### PR DESCRIPTION
refering #67 

Next step is to add codecoverage indicator in README using an external tools to have a global view (similar to https://codecov.io/gh/kubernetes/minikube)

This PR aim to improve developer experience by be able to measure code coverage locally.