### PR TITLE
Creating multi-architecture images using docker manifest tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 BIN_DIR=_output/bin
+DOCKER_REPO=damora
 RELEASE_VER=0.1
 
 kube-arbitrator: init
@@ -22,8 +23,29 @@ images: kube-arbitrator
 	cp ./_output/bin/kar-scheduler ./deployment/
 	cp ./_output/bin/kar-controllers ./deployment/
 	cp ./_output/bin/karcli ./deployment/
-	docker build ./deployment/ -t kubearbitrator/kube-arbitrator:${RELEASE_VER}
+	docker build --no-cache -f ./deployment/Dockerfile.ppc64le.ubuntu ./deployment/  \
+	-t ${DOCKER_REPO}/ppc64le-kube-arbitrator:ubuntu-${RELEASE_VER}
+	docker build --no-cache -f ./deployment/Dockerfile.ppc64le.centos ./deployment/  \
+	-t ${DOCKER_REPO}/ppc64le-kube-arbitrator:centos-${RELEASE_VER}
+	docker build --no-cache -f ./deployment/Dockerfile.amd64.ubuntu ./deployment/  \
+	-t ${DOCKER_REPO}/amd64-kube-arbitrator:ubuntu-${RELEASE_VER} 
 	rm -f ./deployment/kar*
+
+manifest:
+	docker push ${DOCKER_REPO}/ppc64le-kube-arbitrator:ubuntu-${RELEASE_VER}
+	docker push ${DOCKER_REPO}/ppc64le-kube-arbitrator:centos-${RELEASE_VER}
+	docker push ${DOCKER_REPO}/amd64-kube-arbitrator:ubuntu-${RELEASE_VER} 
+	docker manifest create -a ${DOCKER_REPO}/kube-arbitrator:${RELEASE_VER}  	\
+	${DOCKER_REPO}/amd64-kube-arbitrator:ubuntu-${RELEASE_VER}			\
+	${DOCKER_REPO}/ppc64le-kube-arbitrator:centos-${RELEASE_VER}  			\
+	${DOCKER_REPO}/ppc64le-kube-arbitrator:ubuntu-${RELEASE_VER}
+	docker manifest annotate ${DOCKER_REPO}/kube-arbitrator:${RELEASE_VER} 		\
+	${DOCKER_REPO}/amd64-kube-arbitrator:ubuntu-${RELEASE_VER} --arch amd64
+	docker manifest annotate  ${DOCKER_REPO}/kube-arbitrator:${RELEASE_VER} 	\
+	${DOCKER_REPO}/ppc64le-kube-arbitrator:centos-${RELEASE_VER}  --arch ppc64le 
+	docker manifest annotate ${DOCKER_REPO}/kube-arbitrator:${RELEASE_VER} 		\
+	${DOCKER_REPO}/ppc64le-kube-arbitrator:ubuntu-${RELEASE_VER}  --arch ppc64le
+	docker manifest push  ${DOCKER_REPO}/kube-arbitrator:${RELEASE_VER}
 
 run-test:
 	hack/make-rules/test.sh $(WHAT) $(TESTS)

--- a/deployment/Dockerfile.amd64.ubuntu
+++ b/deployment/Dockerfile.amd64.ubuntu
@@ -1,0 +1,11 @@
+From ubuntu:18.04
+
+RUN apt-get update && apt-get install -y supervisor
+
+ADD kar-scheduler /usr/local/bin
+ADD kar-controllers /usr/local/bin
+ADD karcli /usr/local/bin
+
+ADD supervisord.conf /etc
+
+CMD ["/usr/bin/supervisord", "-n"]

--- a/deployment/Dockerfile.ppc64le.centos
+++ b/deployment/Dockerfile.ppc64le.centos
@@ -1,0 +1,12 @@
+FROM  ppc64le/centos:7
+RUN yum -y update && yum clean all
+RUN  yum -y  install python-setuptools
+RUN easy_install supervisor
+
+ADD kar-scheduler /usr/local/bin
+ADD kar-controllers /usr/local/bin
+ADD karcli /usr/local/bin
+
+ADD supervisord.conf /etc/supervisor/
+
+CMD ["/usr/bin/supervisord", "-n"]

--- a/deployment/Dockerfile.ppc64le.ubuntu
+++ b/deployment/Dockerfile.ppc64le.ubuntu
@@ -1,0 +1,11 @@
+From ppc64le/ubuntu
+
+RUN apt-get update && apt-get install -y supervisor
+
+ADD kar-scheduler /usr/local/bin
+ADD kar-controllers /usr/local/bin
+ADD karcli /usr/local/bin
+
+ADD supervisord.conf /etc
+
+CMD ["/usr/bin/supervisord", "-n"]


### PR DESCRIPTION
Added platform specific Dockerfiles for ppc64le, amd64 and ubuntu and centos
Modified existing Makefile adding a manifest build section:
1. This section pushes the architecture specific images to ppc64le-kube-arbitrator and amd64-kube-arbitrator repositories
2. Creates the manifest that includes
   damora/ppc64le-kube-arbitrator:ubuntu-0.1
    damora/ppc64le-kube-arbitrator:centos-0.1
   damora/amd64-kube-arbitrator:ubuntu-0.1
3. pushes the manifest to damora/kube-arbitrator
