### PR TITLE
kube-batchd can not aware of the changes of gpu resources when scale up cluster. 

### DIFF
--- a/pkg/batchd/cache/cache.go
+++ b/pkg/batchd/cache/cache.go
@@ -380,7 +380,7 @@ func (sc *SchedulerCache) addNode(node *v1.Node) error {
 func (sc *SchedulerCache) updateNode(oldNode, newNode *v1.Node) error {
 	// Did not delete the old node, just update related info, e.g. allocatable.
 	if sc.Nodes[newNode.Name] != nil {
-		sc.Nodes[newNode.Name].SetNode(newNode)
+		sc.Nodes[newNode.Name].UpdateNode(oldNode, newNode)
 		return nil
 	}
 

--- a/pkg/batchd/cache/node_info.go
+++ b/pkg/batchd/cache/node_info.go
@@ -18,6 +18,7 @@ package cache
 
 import (
 	"k8s.io/api/core/v1"
+	"reflect"
 )
 
 // NodeInfo is node level aggregated information.
@@ -103,6 +104,22 @@ func (ni *NodeInfo) SetNode(node *v1.Node) {
 	ni.Allocatable = NewResource(node.Status.Allocatable)
 	ni.Capability = NewResource(node.Status.Capacity)
 }
+
+func (ni *NodeInfo) UpdateNode(oldNode, newNode *v1.Node) {
+	if !reflect.DeepEqual(oldNode.Status.Allocatable, newNode.Status.Allocatable) {
+		ni.Idle = NewResource(newNode.Status.Allocatable)
+		ni.Allocatable = NewResource(newNode.Status.Allocatable)
+
+		for _, p := range ni.Pods {
+			ni.Idle.Sub(p.Request)
+			ni.Used.Add(p.Request)
+		}
+	}
+	ni.Name = newNode.Name
+	ni.Node = newNode
+	ni.Capability = NewResource(newNode.Status.Capacity)
+}
+
 
 func (ni *NodeInfo) AddPod(p *PodInfo) {
 	if ni.Node != nil {

--- a/pkg/batchd/cache/node_info.go
+++ b/pkg/batchd/cache/node_info.go
@@ -120,7 +120,6 @@ func (ni *NodeInfo) UpdateNode(oldNode, newNode *v1.Node) {
 	ni.Capability = NewResource(newNode.Status.Capacity)
 }
 
-
 func (ni *NodeInfo) AddPod(p *PodInfo) {
 	if ni.Node != nil {
 		ni.Idle.Sub(p.Request)


### PR DESCRIPTION
fix the issue: [kube-batchd can not aware of the changes of gpu resources when scale up cluster. ](https://github.com/kubernetes-incubator/kube-arbitrator/issues/302)
