### PR TITLE
fix deployment file invalid error

### DIFF
--- a/deployment/kube-arbitrator/templates/deployment.yaml
+++ b/deployment/kube-arbitrator/templates/deployment.yaml
@@ -6,6 +6,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
   replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: kube-batchd
   template:
     metadata:
       labels:


### PR DESCRIPTION
In the original version, this error happened when using Helm to deploy kube-arbitrator

```
spec.selector: Required value
spec.template.metadata.labels: Invalid value: map[string]string{...} selector does not match template labels
```

This PR add selector in spec of Deployment to fix the invalid error.