### PR TITLE
fix e2e error reclaim

### DIFF
--- a/cmd/kube-batchd/app/options/options.go
+++ b/cmd/kube-batchd/app/options/options.go
@@ -48,7 +48,7 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.SchedulerConf, "scheduler-conf", "", "The namespace and name of ConfigMap for scheduler configuration")
 	fs.BoolVar(&s.EnableLeaderElection, "leader-elect", s.EnableLeaderElection, "Start a leader election client and gain leadership before "+
 		"executing the main loop. Enable this when running replicated kar-scheduler for high availability")
-	fs.BoolVar(&s.NamespaceAsQueue, "enable-namespace-as-queue", true, "Make Namespace as Queue with weight one, "+
+	fs.BoolVar(&s.NamespaceAsQueue, "enable-namespace-as-queue", s.NamespaceAsQueue, "Make Namespace as Queue with weight one, "+
 		"but kube-batchd will not handle Queue CRD anymore")
 	fs.StringVar(&s.LockObjectNamespace, "lock-object-namespace", s.LockObjectNamespace, "Define the namespace of the lock object")
 }

--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -4,6 +4,15 @@ export PATH="${HOME}/.kubeadm-dind-cluster:${PATH}"
 export KA_BIN=_output/bin
 export LOG_LEVEL=3
 
+if [ $(echo $RANDOM%2 | bc) -eq 1 ]
+then
+    enable_namespace_as_queue=true
+else
+    enable_namespace_as_queue=false
+fi
+
+export ENABLE_NAMESPACES_AS_QUEUE=$enable_namespace_as_queue
+
 # start k8s dind cluster
 ./hack/dind-cluster-v1.11.sh up
 
@@ -11,7 +20,7 @@ kubectl create -f config/crds/scheduling_v1alpha1_podgroup.yaml
 kubectl create -f config/crds/scheduling_v1alpha1_queue.yaml
 
 # start kube-arbitrator
-nohup ${KA_BIN}/kube-batchd --kubeconfig ${HOME}/.kube/config --logtostderr --v ${LOG_LEVEL} > scheduler.log 2>&1 &
+nohup ${KA_BIN}/kube-batchd --kubeconfig ${HOME}/.kube/config --enable-namespace-as-queue=${ENABLE_NAMESPACES_AS_QUEUE} --logtostderr --v ${LOG_LEVEL} > scheduler.log 2>&1 &
 
 # clean up
 function cleanup {

--- a/test/e2e.go
+++ b/test/e2e.go
@@ -162,8 +162,8 @@ var _ = Describe("E2E Test", func() {
 		context := initTestContext()
 		defer cleanupTestContext(context)
 
-		jobName1 := "q1/qj-1"
-		jobName2 := "q2/qj-2"
+		jobName1 := "n1/qj-1"
+		jobName2 := "n2/qj-2"
 
 		slot := oneCPU
 		rep := clusterSize(context, slot)


### PR DESCRIPTION
fix #360
If we set NamespaceAsQueue to true, kube-batchd will not handle Queue CRD anymore.  Then Reclaim in e2e test will be failed to use queue "q1" and "q2". 