### PR TITLE
apply enabled namespace as Queue to PDB

### DIFF
--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -173,7 +173,7 @@ func (ji *JobInfo) SetPDB(pdb *policyv1.PodDisruptionBudget) {
 	ji.Namespace = pdb.Namespace
 	ji.Queue = QueueID(pdb.Namespace)
 
-	ji.PDB = pbd
+	ji.PDB = pdb
 }
 
 func (ji *JobInfo) UnsetPDB() {

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -167,9 +167,11 @@ func (ji *JobInfo) SetPodGroup(pg *arbcorev1.PodGroup) {
 	ji.PodGroup = pg
 }
 
-func (ji *JobInfo) SetPDB(pbd *policyv1.PodDisruptionBudget) {
-	ji.Name = pbd.Name
-	ji.MinAvailable = pbd.Spec.MinAvailable.IntVal
+func (ji *JobInfo) SetPDB(pdb *policyv1.PodDisruptionBudget) {
+	ji.Name = pdb.Name
+	ji.MinAvailable = pdb.Spec.MinAvailable.IntVal
+	ji.Namespace = pdb.Namespace
+	ji.Queue = QueueID(pdb.Namespace)
 
 	ji.PDB = pbd
 }


### PR DESCRIPTION
This PR apply "enabled namespace as Queue" to PDB to keep consistency with podgroup
or PDB would not work in the integration with tf-operator.