### PR TITLE
Order gang scheduled jobs based on time of arrival

### DIFF
--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -18,9 +18,9 @@ package api
 
 import (
 	"fmt"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	arbcorev1 "github.com/kubernetes-sigs/kube-batch/pkg/apis/scheduling/v1alpha1"
@@ -129,8 +129,7 @@ type JobInfo struct {
 	TotalRequest *Resource
 
 	CreationTimestamp metav1.Time
-	
-	PodGroup *arbcorev1.PodGroup
+	PodGroup          *arbcorev1.PodGroup
 
 	// TODO(k82cn): keep backward compatbility, removed it when v1alpha1 finalized.
 	PDB *policyv1.PodDisruptionBudget
@@ -271,16 +270,16 @@ func (ji *JobInfo) Clone() *JobInfo {
 		NodeSelector: map[string]string{},
 		Allocated:    ji.Allocated.Clone(),
 		TotalRequest: ji.TotalRequest.Clone(),
-		
+
 		PDB:      ji.PDB,
 		PodGroup: ji.PodGroup,
-		
+
 		TaskStatusIndex: map[TaskStatus]tasksMap{},
 		Tasks:           tasksMap{},
 	}
 
 	ji.CreationTimestamp.DeepCopyInto(&info.CreationTimestamp)
-	
+
 	for k, v := range ji.NodeSelector {
 		info.NodeSelector[k] = v
 	}

--- a/pkg/scheduler/plugins/gang/gang.go
+++ b/pkg/scheduler/plugins/gang/gang.go
@@ -120,11 +120,11 @@ func (gp *gangPlugin) OnSessionOpen(ssn *framework.Session) {
 		}
 
 		if !lReady && !rReady {
-			if lv.PodGroup.GetCreationTimestamp().Time.Equal(rv.PodGroup.GetCreationTimestamp().Time) {
+			if lv.CreationTimestamp.Equal(&rv.CreationTimestamp) {
 				if lv.UID < rv.UID {
 					return -1;
 				}
-			} else if lv.PodGroup.GetCreationTimestamp().Time.Before(rv.PodGroup.GetCreationTimestamp().Time) {
+			} else if lv.CreationTimestamp.Before(&rv.CreationTimestamp) {
 				return -1
 			}
 			return 1

--- a/pkg/scheduler/plugins/gang/gang.go
+++ b/pkg/scheduler/plugins/gang/gang.go
@@ -122,7 +122,7 @@ func (gp *gangPlugin) OnSessionOpen(ssn *framework.Session) {
 		if !lReady && !rReady {
 			if lv.CreationTimestamp.Equal(&rv.CreationTimestamp) {
 				if lv.UID < rv.UID {
-					return -1;
+					return -1
 				}
 			} else if lv.CreationTimestamp.Before(&rv.CreationTimestamp) {
 				return -1

--- a/pkg/scheduler/plugins/gang/gang.go
+++ b/pkg/scheduler/plugins/gang/gang.go
@@ -120,7 +120,11 @@ func (gp *gangPlugin) OnSessionOpen(ssn *framework.Session) {
 		}
 
 		if !lReady && !rReady {
-			if lv.UID < rv.UID {
+			if lv.PodGroup.GetCreationTimestamp().Time.Equal(rv.PodGroup.GetCreationTimestamp().Time) {
+				if lv.UID < rv.UID {
+					return -1;
+				}
+			} else if lv.PodGroup.GetCreationTimestamp().Time.Before(rv.PodGroup.GetCreationTimestamp().Time) {
 				return -1
 			}
 			return 1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
The ordering of equal priority gang scheduled jobs is currently based on the job's namespace/name which is unintuitive when multiple users schedule jobs competing for the same resources.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #454 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Equal priority gang scheduled jobs will be ordered by their time of creation.
```

