### PR TITLE
Enable PDB based gang scheduling with discrete queues.

### DIFF
--- a/cmd/kube-batch/app/options/options.go
+++ b/cmd/kube-batch/app/options/options.go
@@ -33,6 +33,18 @@ type ServerOption struct {
 	NamespaceAsQueue     bool
 	EnableLeaderElection bool
 	LockObjectNamespace  string
+	PdbQueue             string
+}
+
+var (
+	opts *ServerOption
+)
+
+func Options() *ServerOption {
+	if opts == nil {
+		opts = &ServerOption{}
+	}
+	return opts
 }
 
 // NewServerOption creates a new CMServer with a default config.
@@ -49,6 +61,7 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.SchedulerName, "scheduler-name", "kube-batch", "kube-batch will handle pods with the scheduler-name")
 	fs.StringVar(&s.SchedulerConf, "scheduler-conf", "", "The namespace and name of ConfigMap for scheduler configuration")
 	fs.StringVar(&s.SchedulePeriod, "schedule-period", "1s", "The period between each scheduling cycle")
+	fs.StringVar(&s.PdbQueue, "pdb-queue", "", "The name of the Queue object to be used with PDBs instead of their namespace name")	
 	fs.BoolVar(&s.EnableLeaderElection, "leader-elect", s.EnableLeaderElection, "Start a leader election client and gain leadership before "+
 		"executing the main loop. Enable this when running replicated kube-batch for high availability")
 	fs.BoolVar(&s.NamespaceAsQueue, "enable-namespace-as-queue", true, "Make Namespace as Queue with weight one, "+

--- a/cmd/kube-batch/app/options/options.go
+++ b/cmd/kube-batch/app/options/options.go
@@ -61,7 +61,7 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.SchedulerName, "scheduler-name", "kube-batch", "kube-batch will handle pods with the scheduler-name")
 	fs.StringVar(&s.SchedulerConf, "scheduler-conf", "", "The namespace and name of ConfigMap for scheduler configuration")
 	fs.StringVar(&s.SchedulePeriod, "schedule-period", "1s", "The period between each scheduling cycle")
-	fs.StringVar(&s.PdbQueue, "pdb-queue", "", "The name of the Queue object to be used with PDBs instead of their namespace name")	
+	fs.StringVar(&s.PdbQueue, "pdb-queue", "", "The name of the Queue object to be used with PDBs instead of their namespace name")
 	fs.BoolVar(&s.EnableLeaderElection, "leader-elect", s.EnableLeaderElection, "Start a leader election client and gain leadership before "+
 		"executing the main loop. Enable this when running replicated kube-batch for high availability")
 	fs.BoolVar(&s.NamespaceAsQueue, "enable-namespace-as-queue", true, "Make Namespace as Queue with weight one, "+

--- a/cmd/kube-batch/app/options/options.go
+++ b/cmd/kube-batch/app/options/options.go
@@ -33,7 +33,7 @@ type ServerOption struct {
 	NamespaceAsQueue     bool
 	EnableLeaderElection bool
 	LockObjectNamespace  string
-	PdbQueue             string
+	DefaultQueue         string
 }
 
 var (
@@ -61,7 +61,7 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.SchedulerName, "scheduler-name", "kube-batch", "kube-batch will handle pods with the scheduler-name")
 	fs.StringVar(&s.SchedulerConf, "scheduler-conf", "", "The namespace and name of ConfigMap for scheduler configuration")
 	fs.StringVar(&s.SchedulePeriod, "schedule-period", "1s", "The period between each scheduling cycle")
-	fs.StringVar(&s.PdbQueue, "pdb-queue", "", "The name of the Queue object to be used with PDBs instead of their namespace name")
+	fs.StringVar(&s.DefaultQueue, "default-queue", "", "The name of the queue to fall-back to instead of namespace name")
 	fs.BoolVar(&s.EnableLeaderElection, "leader-elect", s.EnableLeaderElection, "Start a leader election client and gain leadership before "+
 		"executing the main loop. Enable this when running replicated kube-batch for high availability")
 	fs.BoolVar(&s.NamespaceAsQueue, "enable-namespace-as-queue", true, "Make Namespace as Queue with weight one, "+

--- a/cmd/kube-batch/main.go
+++ b/cmd/kube-batch/main.go
@@ -33,7 +33,7 @@ import (
 var logFlushFreq = pflag.Duration("log-flush-frequency", 5*time.Second, "Maximum number of seconds between log flushes")
 
 func main() {
-	s := options.NewServerOption()
+	s := options.Options()
 	s.AddFlags(pflag.CommandLine)
 
 	flag.InitFlags()

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -160,10 +160,17 @@ func (ji *JobInfo) SetPodGroup(pg *arbcorev1.PodGroup) {
 	ji.Namespace = pg.Namespace
 	ji.MinAvailable = pg.Spec.MinMember
 
-	if len(pg.Spec.Queue) == 0 {
-		ji.Queue = QueueID(pg.Namespace)
-	} else {
+	//set queue name based on the available information
+	//in the following priority order:
+	// 1. queue name from PodGroup spec (if available)
+	// 2. queue name from default-queue command line option (if specified)
+	// 3. namespace name
+	if len(pg.Spec.Queue) > 0 {
 		ji.Queue = QueueID(pg.Spec.Queue)
+	} else if len(options.Options().DefaultQueue) > 0 {
+		ji.Queue = QueueID(options.Options().DefaultQueue)
+	} else {
+		ji.Queue = QueueID(pg.Namespace)
 	}
 
 	ji.CreationTimestamp = pg.GetCreationTimestamp()
@@ -174,10 +181,10 @@ func (ji *JobInfo) SetPDB(pdb *policyv1.PodDisruptionBudget) {
 	ji.Name = pdb.Name
 	ji.MinAvailable = pdb.Spec.MinAvailable.IntVal
 	ji.Namespace = pdb.Namespace
-	if len(options.Options().PdbQueue) == 0 {
+	if len(options.Options().DefaultQueue) == 0 {
 		ji.Queue = QueueID(pdb.Namespace)
 	} else {
-		ji.Queue = QueueID(options.Options().PdbQueue)
+		ji.Queue = QueueID(options.Options().DefaultQueue)
 	}
 
 	ji.CreationTimestamp = pdb.GetCreationTimestamp()

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -23,9 +23,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/kubernetes-sigs/kube-batch/cmd/kube-batch/app/options"
 	arbcorev1 "github.com/kubernetes-sigs/kube-batch/pkg/apis/scheduling/v1alpha1"
 	"github.com/kubernetes-sigs/kube-batch/pkg/apis/utils"
-	"github.com/kubernetes-sigs/kube-batch/cmd/kube-batch/app/options"	
 )
 
 type TaskID types.UID

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -25,6 +25,7 @@ import (
 
 	arbcorev1 "github.com/kubernetes-sigs/kube-batch/pkg/apis/scheduling/v1alpha1"
 	"github.com/kubernetes-sigs/kube-batch/pkg/apis/utils"
+	"github.com/kubernetes-sigs/kube-batch/cmd/kube-batch/app/options"	
 )
 
 type TaskID types.UID
@@ -173,7 +174,11 @@ func (ji *JobInfo) SetPDB(pdb *policyv1.PodDisruptionBudget) {
 	ji.Name = pdb.Name
 	ji.MinAvailable = pdb.Spec.MinAvailable.IntVal
 	ji.Namespace = pdb.Namespace
-	ji.Queue = QueueID(pdb.Namespace)
+	if len(options.Options().PdbQueue) == 0 {
+		ji.Queue = QueueID(pdb.Namespace)
+	} else {
+		ji.Queue = QueueID(options.Options().PdbQueue)
+	}
 
 	ji.CreationTimestamp = pdb.GetCreationTimestamp()
 	ji.PDB = pdb


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Currently it's not possible to schedule PDB based gangs when the `enable-namespace-as-queue` option is disabled. This PR introduces an option to set the name of the queue to be used with PDB based jobs via the command line (if not specified the name of the namespace is still used).
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
It's now possible to scheduled PDB based jobs while the `enable-namespace-as-queue` option is set to `false`. The new `pdb-queue` command line option allows to manually select the queue to be used for PDB based jobs in such cases.
```

