### PR TITLE
Fix typo in tutorial.md

### DIFF
--- a/doc/usage/tutorial.md
+++ b/doc/usage/tutorial.md
@@ -81,7 +81,7 @@ spec:
   minMember: 6
 ```
 
-The yaml file means a Job named `qj-01` to create 6 pods(it is specified by `parallelism`), these pods will be scheduled by scheduler `kube-batch` (it is specified by `schedulerName`). `kube-batch` will watch `PodGroup`, and the annotation `scheduling.k8s.io/group-name` identify which group the pod belongs to. `kube-batch` will start `.spec.numMember` pods for a Job at the same time; otherwise, such as resources are not sufficient, `kube-batch` will not start any pods for the Job.
+The yaml file means a Job named `qj-01` to create 6 pods(it is specified by `parallelism`), these pods will be scheduled by scheduler `kube-batch` (it is specified by `schedulerName`). `kube-batch` will watch `PodGroup`, and the annotation `scheduling.k8s.io/group-name` identify which group the pod belongs to. `kube-batch` will start `.spec.minMember` pods for a Job at the same time; otherwise, such as resources are not sufficient, `kube-batch` will not start any pods for the Job.
 
 Create the Job
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In tutorial.md, "kube-batch will start ````.spec.numMember```` pods for a Job at the same time;" should be "kube-batch will start ````.spec.minMember```` pods for a Job at the same time;"

This PR fixes this typo.
