### PR TITLE
Add version options for kube-batch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,15 @@
 BIN_DIR=_output/bin
 RELEASE_VER=v0.2
+REPO_PATH=github.com/kubernetes-sigs/kube-batch
+GitSHA=`git rev-parse HEAD`
+Date=`date "+%Y-%m-%d %H:%M:%S"`
 
 kube-batch: init
-	go build -o ${BIN_DIR}/kube-batch ./cmd/kube-batch/
+	go build  -ldflags " \
+	-X '${REPO_PATH}/pkg/version.GitSHA=${GitSHA}' \
+	-X '${REPO_PATH}/pkg/version.Built=${Date}'   \
+	-X '${REPO_PATH}/pkg/version.Version=${RELEASE_VER}'" \
+	-o _output/bin/kube-batch ./cmd/kube-batch
 
 verify: generate-code
 	hack/verify-gofmt.sh

--- a/cmd/kube-batch/app/options/options.go
+++ b/cmd/kube-batch/app/options/options.go
@@ -34,6 +34,7 @@ type ServerOption struct {
 	EnableLeaderElection bool
 	LockObjectNamespace  string
 	DefaultQueue         string
+	PrintVersion         bool
 }
 
 var (
@@ -66,6 +67,7 @@ func (s *ServerOption) AddFlags(fs *pflag.FlagSet) {
 		"executing the main loop. Enable this when running replicated kube-batch for high availability")
 	fs.BoolVar(&s.NamespaceAsQueue, "enable-namespace-as-queue", true, "Make Namespace as Queue with weight one, "+
 		"but kube-batch will not handle Queue CRD anymore")
+	fs.BoolVar(&s.PrintVersion, "version", false, "Show version and quit")
 	fs.StringVar(&s.LockObjectNamespace, "lock-object-namespace", s.LockObjectNamespace, "Define the namespace of the lock object")
 }
 

--- a/cmd/kube-batch/app/server.go
+++ b/cmd/kube-batch/app/server.go
@@ -24,6 +24,8 @@ import (
 	"github.com/golang/glog"
 	"github.com/kubernetes-sigs/kube-batch/cmd/kube-batch/app/options"
 	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler"
+	"github.com/kubernetes-sigs/kube-batch/pkg/version"
+
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	clientset "k8s.io/client-go/kubernetes"
@@ -42,6 +44,7 @@ const (
 	leaseDuration = 15 * time.Second
 	renewDeadline = 10 * time.Second
 	retryPeriod   = 5 * time.Second
+	apiVersion    = "v1alpha1"
 )
 
 func buildConfig(master, kubeconfig string) (*rest.Config, error) {
@@ -52,6 +55,10 @@ func buildConfig(master, kubeconfig string) (*rest.Config, error) {
 }
 
 func Run(opt *options.ServerOption) error {
+	if opt.PrintVersion {
+		version.PrintVersionAndExit(apiVersion)
+	}
+
 	config, err := buildConfig(opt.Master, opt.Kubeconfig)
 	if err != nil {
 		return err

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+)
+
+var (
+	// Version shows the version of kube-batch.
+	Version = "Not provided."
+	// GitSHA shoows the git commit id of kube-batch.
+	GitSHA = "Not provided."
+	// Built shows the built time of the binary.
+	Built = "Not provided."
+)
+
+// PrintVersionAndExit prints versions from the array returned by Info() and exit
+func PrintVersionAndExit(apiVersion string) {
+	for _, i := range Info(apiVersion) {
+		fmt.Printf("%v\n", i)
+	}
+	os.Exit(0)
+}
+
+// Info returns an array of various service versions
+func Info(apiVersion string) []string {
+	return []string{
+		fmt.Sprintf("API Version: %s", apiVersion),
+		fmt.Sprintf("Version: %s", Version),
+		fmt.Sprintf("Git SHA: %s", GitSHA),
+		fmt.Sprintf("Built At: %s", Built),
+		fmt.Sprintf("Go Version: %s", runtime.Version()),
+		fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
```
$ make 
mkdir -p _output/bin
go build  -ldflags " \
        -X 'github.com/kubernetes-sigs/kube-batch/pkg/version.GitSHA=`git rev-parse HEAD`' \
        -X 'github.com/kubernetes-sigs/kube-batch/pkg/version.Built=`date "+%Y-%m-%d %H:%M:%S"`'   \
        -X 'github.com/kubernetes-sigs/kube-batch/pkg/version.Version=v0.2'" \
        -o _output/bin/kube-batch ./cmd/kube-batch
$  _output/bin/kube-batch --version 
API Version: v1alpha1
Version: v0.2
Git SHA: aaf29293a165477afec79b77ea4b1cad3bac030e
Built At: 2018-12-05 16:12:54
Go Version: go1.11.1
Go OS/Arch: darwin/amd64
```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

