### PR TITLE
Update nodeInfo once node was cordoned

### DIFF
--- a/pkg/scheduler/cache/event_handlers.go
+++ b/pkg/scheduler/cache/event_handlers.go
@@ -242,7 +242,8 @@ func (sc *SchedulerCache) addNode(node *v1.Node) error {
 func isNodeInfoUpdated(oldNode, newNode *v1.Node) bool {
 	return !reflect.DeepEqual(oldNode.Status.Allocatable, newNode.Status.Allocatable) ||
 		!reflect.DeepEqual(oldNode.Spec.Taints, newNode.Spec.Taints) ||
-		!reflect.DeepEqual(oldNode.Labels, newNode.Labels)
+		!reflect.DeepEqual(oldNode.Labels, newNode.Labels) ||
+		!reflect.DeepEqual(oldNode.Spec.Unschedulable, newNode.Spec.Unschedulable)
 }
 
 // Assumes that lock is already acquired.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #453 with #455 
need to update the nodeInfo once the node was cordoned.
#uns
**Special notes for your reviewer**:
/assign @k82cn 
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

