### PR TITLE
PodGroup can not be reclaimed.

### DIFF
--- a/pkg/scheduler/plugins/gang/gang.go
+++ b/pkg/scheduler/plugins/gang/gang.go
@@ -100,6 +100,10 @@ func (gp *gangPlugin) OnSessionOpen(ssn *framework.Session) {
 
 		return victims
 	}
+
+	// TODO(k82cn): Support preempt/reclaim batch job.
+	ssn.AddReclaimableFn(preemptableFn)
+
 	if gp.args.PreemptableFnEnabled {
 		ssn.AddPreemptableFn(preemptableFn)
 	}


### PR DESCRIPTION
Signed-off-by: Da K. Ma <klaus1982.cn@gmail.com>

**Release note**:
```release-note
The Pod of PodGroup that below `spec.minMember` can not be reclaimed.
```

