### PR TITLE
Automated cherry pick of #509: PodGroup can not be reclaimed.

### DIFF
--- a/pkg/scheduler/plugins/gang/gang.go
+++ b/pkg/scheduler/plugins/gang/gang.go
@@ -100,6 +100,10 @@ func (gp *gangPlugin) OnSessionOpen(ssn *framework.Session) {
 
 		return victims
 	}
+
+	// TODO(k82cn): Support preempt/reclaim batch job.
+	ssn.AddReclaimableFn(preemptableFn)
+
 	if gp.args.PreemptableFnEnabled {
 		ssn.AddPreemptableFn(preemptableFn)
 	}


### PR DESCRIPTION
Cherry pick of #509 on release-0.3.

#509: PodGroup can not be reclaimed.