### PR TITLE
Add e2e test for different task resource requests

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -47,6 +47,7 @@ import (
 
 var oneMinute = 1 * time.Minute
 
+var halfCPU = v1.ResourceList{"cpu": resource.MustParse("500m")}
 var oneCPU = v1.ResourceList{"cpu": resource.MustParse("1000m")}
 var twoCPU = v1.ResourceList{"cpu": resource.MustParse("2000m")}
 var threeCPU = v1.ResourceList{"cpu": resource.MustParse("3000m")}
@@ -259,6 +260,7 @@ type jobSpec struct {
 	namespace string
 	queue     string
 	tasks     []taskSpec
+	minMember *int32
 }
 
 func getNS(context *context, job *jobSpec) string {
@@ -326,6 +328,10 @@ func createJobEx(context *context, job *jobSpec) ([]*batchv1.Job, *arbv1.PodGrou
 			MinMember: min,
 			Queue:     job.queue,
 		},
+	}
+
+	if job.minMember != nil {
+		pg.Spec.MinMember = *job.minMember
 	}
 
 	podgroup, err := context.karclient.Scheduling().PodGroups(pg.Namespace).Create(pg)


### PR DESCRIPTION

**What this PR does / why we need it**:
We talked about adding one task case for different task resource requests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Mentioned in #540 

**Special notes for your reviewer**:
I use milliCPU here and should be fine to cover different node groups. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add e2e test for different task resource requests
```

