### PR TITLE
Reduce verbosity level for recurring logs

### DIFF
--- a/contrib/DLaaS/pkg/scheduler/plugins/priority/priority.go
+++ b/contrib/DLaaS/pkg/scheduler/plugins/priority/priority.go
@@ -60,7 +60,7 @@ func (pp *priorityPlugin) OnSessionOpen(ssn *framework.Session) {
 		lv := l.(*api.JobInfo)
 		rv := r.(*api.JobInfo)
 
-		glog.V(3).Infof("Priority JobOrderFn: <%v/%v> is ready: %d, <%v/%v> is ready: %d",
+		glog.V(4).Infof("Priority JobOrderFn: <%v/%v> is ready: %d, <%v/%v> is ready: %d",
 			lv.Namespace, lv.Name, lv.Priority, rv.Namespace, rv.Name, rv.Priority)
 
 		if lv.Priority > rv.Priority {

--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -54,7 +54,7 @@ func (alloc *allocateAction) Execute(ssn *framework.Session) {
 			queues.Push(queue)
 		}
 
-		glog.V(3).Infof("Added Job <%s/%s> into Queue <%s>", job.Namespace, job.Name, job.Queue)
+		glog.V(4).Infof("Added Job <%s/%s> into Queue <%s>", job.Namespace, job.Name, job.Queue)
 		jobsMap[job.Queue].Push(job)
 	}
 
@@ -78,7 +78,7 @@ func (alloc *allocateAction) Execute(ssn *framework.Session) {
 		glog.V(3).Infof("Try to allocate resource to Jobs in Queue <%v>", queue.Name)
 
 		if !found || jobs.Empty() {
-			glog.V(3).Infof("Can not find jobs for queue %s.", queue.Name)
+			glog.V(4).Infof("Can not find jobs for queue %s.", queue.Name)
 			continue
 		}
 
@@ -88,7 +88,7 @@ func (alloc *allocateAction) Execute(ssn *framework.Session) {
 			for _, task := range job.TaskStatusIndex[api.Pending] {
 				// Skip BestEffort task in 'allocate' action.
 				if task.Resreq.IsEmpty() {
-					glog.V(3).Infof("Task <%v/%v> is BestEffort task, skip it.",
+					glog.V(4).Infof("Task <%v/%v> is BestEffort task, skip it.",
 						task.Namespace, task.Name)
 					continue
 				}

--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -78,7 +78,7 @@ func (alloc *preemptAction) Execute(ssn *framework.Session) {
 
 			// If no preemptors, no preemption.
 			if preemptors == nil || preemptors.Empty() {
-				glog.V(3).Infof("No preemptors in Queue <%s>, break.", queue.Name)
+				glog.V(4).Infof("No preemptors in Queue <%s>, break.", queue.Name)
 				break
 			}
 

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -57,7 +57,7 @@ func (alloc *reclaimAction) Execute(ssn *framework.Session) {
 				job.Queue, job.Namespace, job.Name)
 			continue
 		} else {
-			glog.V(3).Infof("Added Queue <%s> for Job <%s/%s>",
+			glog.V(4).Infof("Added Queue <%s> for Job <%s/%s>",
 				queue.Name, job.Namespace, job.Name)
 			queues.Push(queue)
 		}

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -503,7 +503,7 @@ func (sc *SchedulerCache) Snapshot() *arbapi.ClusterInfo {
 	for _, value := range sc.Jobs {
 		// If no scheduling spec, does not handle it.
 		if value.PodGroup == nil && value.PDB == nil {
-			glog.V(3).Infof("The scheduling spec of Job <%v:%s/%s> is nil, ignore it.",
+			glog.V(4).Infof("The scheduling spec of Job <%v:%s/%s> is nil, ignore it.",
 				value.UID, value.Namespace, value.Name)
 
 			// Also tracing the running task assigned by other scheduler.

--- a/pkg/scheduler/plugins/gang/gang.go
+++ b/pkg/scheduler/plugins/gang/gang.go
@@ -113,7 +113,7 @@ func (gp *gangPlugin) OnSessionOpen(ssn *framework.Session) {
 		lReady := jobReady(lv)
 		rReady := jobReady(rv)
 
-		glog.V(3).Infof("Gang JobOrderFn: <%v/%v> is ready: %t, <%v/%v> is ready: %t",
+		glog.V(4).Infof("Gang JobOrderFn: <%v/%v> is ready: %t, <%v/%v> is ready: %t",
 			lv.Namespace, lv.Name, lReady, rv.Namespace, rv.Name, rReady)
 
 		if lReady && rReady {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Reduce log verbosity level for recurring operations. More details in issue linked below.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #557 

**Special notes for your reviewer**:

**Release note**:
(I'm not sure if including these changes in release notes in necessary)
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Reduced log verbosity level from 3 to 4 for following operations:
* Priority JobOrderFn readiness info
* Adding Job to Queue
* Information about no jobs found for queue
* Information about skipping BestEffort tasks
* Info about lack of preemptors in queue
* Info about nil scheduling spec of a job
* Info about Gang JobOrderFn readiness
```

