### PR TITLE
Added a unit test for jobOrderFn in gang plugin

### DIFF
--- a/pkg/scheduler/plugins/gang/gang.go
+++ b/pkg/scheduler/plugins/gang/gang.go
@@ -129,31 +129,6 @@ func (gp *gangPlugin) OnSessionOpen(ssn *framework.Session) {
 	ssn.AddReclaimableFn(gp.Name(), preemptableFn)
 	ssn.AddPreemptableFn(gp.Name(), preemptableFn)
 
-	jobOrderFn := func(l, r interface{}) int {
-		lv := l.(*api.JobInfo)
-		rv := r.(*api.JobInfo)
-
-		lReady := jobReady(lv)
-		rReady := jobReady(rv)
-
-		glog.V(4).Infof("Gang JobOrderFn: <%v/%v> is ready: %t, <%v/%v> is ready: %t",
-			lv.Namespace, lv.Name, lReady, rv.Namespace, rv.Name, rReady)
-
-		if lReady && rReady {
-			return 0
-		}
-
-		if lReady {
-			return 1
-		}
-
-		if rReady {
-			return -1
-		}
-
-		return 0
-	}
-
 	ssn.AddJobOrderFn(gp.Name(), jobOrderFn)
 	ssn.AddJobReadyFn(gp.Name(), jobReady)
 }
@@ -188,4 +163,29 @@ func (gp *gangPlugin) OnSessionClose(ssn *framework.Session) {
 	}
 
 	metrics.UpdateUnscheduleJobCount(unScheduleJobCount)
+}
+
+func jobOrderFn(l, r interface{}) int {
+	lv := l.(*api.JobInfo)
+	rv := r.(*api.JobInfo)
+
+	lReady := jobReady(lv)
+	rReady := jobReady(rv)
+
+	glog.V(4).Infof("Gang JobOrderFn: <%v/%v> is ready: %t, <%v/%v> is ready: %t",
+		lv.Namespace, lv.Name, lReady, rv.Namespace, rv.Name, rReady)
+
+	if lReady && rReady {
+		return 0
+	}
+
+	if lReady {
+		return 1
+	}
+
+	if rReady {
+		return -1
+	}
+
+	return 0
 }

--- a/pkg/scheduler/plugins/gang/gang_test.go
+++ b/pkg/scheduler/plugins/gang/gang_test.go
@@ -1,0 +1,84 @@
+package gang
+
+import (
+	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler/api"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func TestJobOrderFn(t *testing.T) {
+	creationTime := metav1.Now()
+
+	readyJob := buildJob(api.JobID("ready-job"), 1, metav1.Now())
+	readyJob.AddTaskInfo(buildTask(api.TaskID("running-task"), readyJob.UID, api.Running))
+
+	nonReadyJob := buildJob(api.JobID("unready-job"), 1, creationTime)
+	nonReadyJob.AddTaskInfo(buildTask(api.TaskID("pending-task"), nonReadyJob.UID, api.Pending))
+
+	nonReadyJobSameCreationTime := buildJob(api.JobID("unready-job-same-creation-time"), 1, creationTime)
+	nonReadyJobSameCreationTime.AddTaskInfo(buildTask(api.TaskID("pending-task"), nonReadyJobSameCreationTime.UID, api.Pending))
+
+	nonReadyJobLaterCreationTime := buildJob(api.JobID("unready-job-later-creation-time"), 1, metav1.Now())
+	nonReadyJobLaterCreationTime.AddTaskInfo(buildTask(api.TaskID("pending-task"), nonReadyJobLaterCreationTime.UID, api.Pending))
+
+	tests := []struct{
+		name string
+		l *api.JobInfo
+		r *api.JobInfo
+		expected int
+	} {
+		{
+			name: "Ready job is greater than unready job",
+			l: readyJob,
+			r: nonReadyJob,
+			expected: 1,
+		},
+		{
+			name: "Unready job is less than ready job",
+			l: nonReadyJob,
+			r: readyJob,
+			expected: -1,
+		},
+		{
+			name: "Ready jobs are equal",
+			l: readyJob,
+			r: readyJob,
+			expected: 0,
+		},
+		{
+			name: "An unready job should be equal to itself",
+			l: nonReadyJob,
+			r: nonReadyJob,
+			expected: 0,
+		},
+		{
+			name: "Unready jobs are equal",
+			l: nonReadyJob,
+			r: nonReadyJobLaterCreationTime,
+			expected: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		actual := jobOrderFn(tc.l, tc.r)
+		if tc.expected != actual {
+			t.Errorf("expected: %v, got: %v. Test case: %s, l-value: '%v', r-value: '%v'", tc.expected, actual, tc.name, tc.l, tc.r)
+		}
+	}
+}
+
+func buildJob(jid api.JobID, minAvailable int32, creationTime metav1.Time) *api.JobInfo {
+	job := api.NewJobInfo(jid)
+	job.MinAvailable = minAvailable
+	job.CreationTimestamp = creationTime
+	return job
+}
+
+func buildTask(tid api.TaskID, jid api.JobID, status api.TaskStatus) *api.TaskInfo {
+	return 	&api.TaskInfo{
+		UID:       tid,
+		Job:       jid,
+		Resreq:    api.EmptyResource(),
+		Status:    status,
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PR added a unit test for `jobOrderFn` in Gang plugin.  

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

