### PR TITLE
Rename PrioritizeFn to NodeOrderFn

### DIFF
--- a/config/kube-batch-conf.yaml
+++ b/config/kube-batch-conf.yaml
@@ -8,4 +8,4 @@ tiers:
   - name: drf
   - name: predicates
   - name: proportion
-  - name: prioritize
+  - name: nodeorder

--- a/example/kube-batch-conf.yaml
+++ b/example/kube-batch-conf.yaml
@@ -8,4 +8,4 @@ tiers:
   - name: drf
   - name: predicates
   - name: proportion
-  - name: prioritize
+  - name: nodeorder

--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -132,7 +132,7 @@ func (alloc *allocateAction) Execute(ssn *framework.Session) {
 				}
 			}
 			for _, node := range predicateNodes {
-				score, err := ssn.PriorityFn(task, node)
+				score, err := ssn.NodeOrderFn(task, node)
 				if err != nil {
 					glog.V(3).Infof("Error in Calculating Priority for the node:%v", err)
 				} else {

--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -188,7 +188,7 @@ func preempt(
 		}
 	}
 	for _, node := range predicateNodes {
-		score, err := ssn.PriorityFn(preemptor, node)
+		score, err := ssn.NodeOrderFn(preemptor, node)
 		if err != nil {
 			glog.V(3).Infof("Error in Calculating Priority for the node:%v", err)
 		} else {

--- a/pkg/scheduler/api/types.go
+++ b/pkg/scheduler/api/types.go
@@ -103,5 +103,5 @@ type PredicateFn func(*TaskInfo, *NodeInfo) error
 // EvictableFn is the func declaration used to evict tasks.
 type EvictableFn func(*TaskInfo, []*TaskInfo) []*TaskInfo
 
-// PriorityFn is the func declaration used to get priority score for a node for a particular task.
-type PriorityFn func(*TaskInfo, *NodeInfo) (int, error)
+// NodeOrderFn is the func declaration used to get priority score for a node for a particular task.
+type NodeOrderFn func(*TaskInfo, *NodeInfo) (int, error)

--- a/pkg/scheduler/conf/scheduler_conf.go
+++ b/pkg/scheduler/conf/scheduler_conf.go
@@ -47,6 +47,6 @@ type PluginOption struct {
 	QueueOrderDisabled bool `yaml:"disableQueueOrder"`
 	// PredicateDisabled defines whether predicateFn is disabled
 	PredicateDisabled bool `yaml:"disablePredicate"`
-	// PriortizeDisabled defines whether PriorityFn is disabled
-	PriortizeDisabled bool `yaml:"disablePrioritize"`
+	// NodeOrderDisabled defines whether NodeOrderFn is disabled
+	NodeOrderDisabled bool `yaml:"disableNodeOrder"`
 }

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -49,7 +49,7 @@ type Session struct {
 	queueOrderFns  map[string]api.CompareFn
 	taskOrderFns   map[string]api.CompareFn
 	predicateFns   map[string]api.PredicateFn
-	priorityFns    map[string]api.PriorityFn
+	nodeOrderFns   map[string]api.NodeOrderFn
 	preemptableFns map[string]api.EvictableFn
 	reclaimableFns map[string]api.EvictableFn
 	overusedFns    map[string]api.ValidateFn
@@ -71,7 +71,7 @@ func openSession(cache cache.Cache) *Session {
 		queueOrderFns:  map[string]api.CompareFn{},
 		taskOrderFns:   map[string]api.CompareFn{},
 		predicateFns:   map[string]api.PredicateFn{},
-		priorityFns:    map[string]api.PriorityFn{},
+		nodeOrderFns:   map[string]api.NodeOrderFn{},
 		preemptableFns: map[string]api.EvictableFn{},
 		reclaimableFns: map[string]api.EvictableFn{},
 		overusedFns:    map[string]api.ValidateFn{},

--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -48,8 +48,8 @@ func (ssn *Session) AddPredicateFn(name string, pf api.PredicateFn) {
 	ssn.predicateFns[name] = pf
 }
 
-func (ssn *Session) AddPriorityFn(name string, pf api.PriorityFn) {
-	ssn.priorityFns[name] = pf
+func (ssn *Session) AddNodeOrderFn(name string, pf api.NodeOrderFn) {
+	ssn.nodeOrderFns[name] = pf
 }
 
 func (ssn *Session) AddOverusedFn(name string, fn api.ValidateFn) {
@@ -298,14 +298,14 @@ func (ssn *Session) PredicateFn(task *api.TaskInfo, node *api.NodeInfo) error {
 	return nil
 }
 
-func (ssn *Session) PriorityFn(task *api.TaskInfo, node *api.NodeInfo) (int, error) {
+func (ssn *Session) NodeOrderFn(task *api.TaskInfo, node *api.NodeInfo) (int, error) {
 	priorityScore := 0
 	for _, tier := range ssn.Tiers {
 		for _, plugin := range tier.Plugins {
-			if plugin.PriortizeDisabled {
+			if plugin.NodeOrderDisabled {
 				continue
 			}
-			pfn, found := ssn.priorityFns[plugin.Name]
+			pfn, found := ssn.nodeOrderFns[plugin.Name]
 			if !found {
 				continue
 			}

--- a/pkg/scheduler/plugins/factory.go
+++ b/pkg/scheduler/plugins/factory.go
@@ -22,8 +22,8 @@ import (
 	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler/plugins/conformance"
 	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler/plugins/drf"
 	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler/plugins/gang"
+	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler/plugins/nodeorder"
 	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler/plugins/predicates"
-	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler/plugins/prioritize"
 	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler/plugins/priority"
 	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler/plugins/proportion"
 )
@@ -34,7 +34,7 @@ func init() {
 	framework.RegisterPluginBuilder("gang", gang.New)
 	framework.RegisterPluginBuilder("predicates", predicates.New)
 	framework.RegisterPluginBuilder("priority", priority.New)
-	framework.RegisterPluginBuilder("prioritize", prioritize.New)
+	framework.RegisterPluginBuilder("nodeorder", nodeorder.New)
 	framework.RegisterPluginBuilder("conformance", conformance.New)
 
 	// Plugins for Queues

--- a/pkg/scheduler/plugins/nodeorder/nodeorder.go
+++ b/pkg/scheduler/plugins/nodeorder/nodeorder.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package prioritize
+package nodeorder
 
 import (
 	"fmt"
@@ -32,7 +32,7 @@ import (
 	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler/framework"
 )
 
-type prioritizePlugin struct {
+type nodeOrderPlugin struct {
 }
 
 func getInterPodAffinityScore(name string, interPodAffinityScore schedulerapi.HostPriorityList) int {
@@ -146,15 +146,15 @@ func (nl *nodeLister) List() ([]*v1.Node, error) {
 
 //New function returns prioritizePlugin object
 func New() framework.Plugin {
-	return &prioritizePlugin{}
+	return &nodeOrderPlugin{}
 }
 
-func (pp *prioritizePlugin) Name() string {
-	return "prioritize"
+func (pp *nodeOrderPlugin) Name() string {
+	return "nodeorder"
 }
 
-func (pp *prioritizePlugin) OnSessionOpen(ssn *framework.Session) {
-	priorityFn := func(task *api.TaskInfo, node *api.NodeInfo) (int, error) {
+func (pp *nodeOrderPlugin) OnSessionOpen(ssn *framework.Session) {
+	nodeOrderFn := func(task *api.TaskInfo, node *api.NodeInfo) (int, error) {
 
 		pl := &podLister{
 			session: ssn,
@@ -207,8 +207,8 @@ func (pp *prioritizePlugin) OnSessionOpen(ssn *framework.Session) {
 		glog.V(4).Infof("Total Score for that node is: %d", score)
 		return score, nil
 	}
-	ssn.AddPriorityFn(pp.Name(), priorityFn)
+	ssn.AddNodeOrderFn(pp.Name(), nodeOrderFn)
 }
 
-func (pp *prioritizePlugin) OnSessionClose(ssn *framework.Session) {
+func (pp *nodeOrderPlugin) OnSessionClose(ssn *framework.Session) {
 }

--- a/pkg/scheduler/util.go
+++ b/pkg/scheduler/util.go
@@ -37,7 +37,7 @@ tiers:
   - name: drf
   - name: predicates
   - name: proportion
-  - name: prioritize
+  - name: nodeorder
 `
 
 func loadSchedulerConf(confStr string) ([]framework.Action, []conf.Tier, error) {

--- a/test/e2e/nodeorder.go
+++ b/test/e2e/nodeorder.go
@@ -25,7 +25,7 @@ import (
 	kubeletapi "k8s.io/kubernetes/pkg/kubelet/apis"
 )
 
-var _ = Describe("Prioritize E2E Test", func() {
+var _ = Describe("NodeOrder E2E Test", func() {
 	It("Node Affinity Test", func() {
 		context := initTestContext()
 		defer cleanupTestContext(context)


### PR DESCRIPTION
**What this PR does / why we need it**:
Renamed Prioritize Plugin to NodeOrder Plugin
**Which issue(s) this PR fixes**:
Fixes # https://github.com/kubernetes-sigs/kube-batch/issues/624

