### PR TITLE
Fix helm deployment

### DIFF
--- a/deployment/kube-batch/templates/deployment.yaml
+++ b/deployment/kube-batch/templates/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}/kube-batch:{{ .Values.image.tag }}"
-        args: ["--logtostderr", "--v", "3", "--enable-namespace-as-queue"]
+        args: ["--logtostderr", "--v", "3"]
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Kube-batch crashes when deployed using helm.  `--enable-namespace-as-queue` has been removed, but helm deployment uses it. So have removed that flag from deployment.