### PR TITLE
Add helm hook crd-install to fix helm install error

### DIFF
--- a/deployment/kube-batch/templates/scheduling_v1alpha1_podgroup.yaml
+++ b/deployment/kube-batch/templates/scheduling_v1alpha1_podgroup.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: podgroups.scheduling.incubator.k8s.io
+  annotations:
+    "helm.sh/hook": "crd-install"
 spec:
   group: scheduling.incubator.k8s.io
   names:

--- a/deployment/kube-batch/templates/scheduling_v1alpha1_queue.yaml
+++ b/deployment/kube-batch/templates/scheduling_v1alpha1_queue.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: queues.scheduling.incubator.k8s.io
+  annotations:
+    "helm.sh/hook": "crd-install"
 spec:
   group: scheduling.incubator.k8s.io
   names:


### PR DESCRIPTION
**What this PR does / why we need it**:
There is an error when running `helm install $GOPATH/src/github.com/kubernetes-sigs/kube-batch/deployment/kube-batch --namespace kube-system`.

Error message:

> $ helm install deployment/kube-batch --namespace kube-system
Error: validation failed: unable to recognize "": no matches for kind "Queue" in version "scheduling.incubator.k8s.io/v1alpha1"

It is because helm does not guarantee that `deployment/kube-batch/templates/scheduling_v1alpha1_queue.yaml` will be executed before `deployment/kube-batch/templates/default.yaml`. However we could add a helm hook [`crd-install`](https://github.com/helm/helm/blob/master/docs/charts_hooks.md) to guarantee it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add helm hook crd-install to fix helm install error
```

