### PR TITLE
Order task, job, queue by CreationTimestamp first, then by UID

### DIFF
--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -241,11 +241,14 @@ func (ssn *Session) QueueOrderFn(l, r interface{}) bool {
 		}
 	}
 
-	// If no queue order funcs, order queue by UID.
+	// If no queue order funcs, order queue by CreationTimestamp first, then by UID.
 	lv := l.(*api.QueueInfo)
 	rv := r.(*api.QueueInfo)
-
-	return lv.UID < rv.UID
+	if lv.Queue.CreationTimestamp.Equal(&rv.Queue.CreationTimestamp) {
+		return lv.UID < rv.UID
+	} else {
+		return lv.Queue.CreationTimestamp.Before(&rv.Queue.CreationTimestamp)
+	}
 }
 
 func (ssn *Session) TaskCompareFns(l, r interface{}) int {

--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -272,11 +272,14 @@ func (ssn *Session) TaskOrderFn(l, r interface{}) bool {
 		return res < 0
 	}
 
-	// If no task order funcs, order task by UID.
+	// If no task order funcs, order task by CreationTimestamp first, then by UID.
 	lv := l.(*api.TaskInfo)
 	rv := r.(*api.TaskInfo)
-
-	return lv.UID < rv.UID
+	if lv.Pod.CreationTimestamp.Equal(&rv.Pod.CreationTimestamp) {
+		return lv.UID < rv.UID
+	} else {
+		return lv.Pod.CreationTimestamp.Before(&rv.Pod.CreationTimestamp)
+	}
 }
 
 func (ssn *Session) PredicateFn(task *api.TaskInfo, node *api.NodeInfo) error {

--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -213,15 +213,14 @@ func (ssn *Session) JobOrderFn(l, r interface{}) bool {
 		}
 	}
 
-	// If no job order funcs, order job by UID.
+	// If no job order funcs, order job by CreationTimestamp first, then by UID.
 	lv := l.(*api.JobInfo)
 	rv := r.(*api.JobInfo)
-
 	if lv.CreationTimestamp.Equal(&rv.CreationTimestamp) {
 		return lv.UID < rv.UID
+	} else {
+		return lv.CreationTimestamp.Before(&rv.CreationTimestamp)
 	}
-
-	return lv.CreationTimestamp.Before(&rv.CreationTimestamp)
 }
 
 func (ssn *Session) QueueOrderFn(l, r interface{}) bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
When other compare functions does not work well, it might be more meaningful to order task, job, queue by CreationTimestamp first, then by UID.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

