### PR TITLE
Allocate: when failing to allocate for one task, continue to allocate…

### DIFF
--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -107,7 +107,6 @@ func (alloc *allocateAction) Execute(ssn *framework.Session) {
 			nodeScores := map[int][]*api.NodeInfo{}
 
 			task := tasks.Pop().(*api.TaskInfo)
-			assigned := false
 
 			glog.V(3).Infof("There are <%d> nodes for Job <%v/%v>",
 				len(ssn.Nodes), job.Namespace, job.Name)
@@ -151,7 +150,6 @@ func (alloc *allocateAction) Execute(ssn *framework.Session) {
 							task.UID, node.Name, ssn.UID, err)
 						continue
 					}
-					assigned = true
 					break
 				} else {
 					//store information about missing resources
@@ -170,14 +168,8 @@ func (alloc *allocateAction) Execute(ssn *framework.Session) {
 							task.UID, node.Name, ssn.UID)
 						continue
 					}
-
-					assigned = true
 					break
 				}
-			}
-
-			if !assigned {
-				break
 			}
 
 			if ssn.JobReady(job) {


### PR DESCRIPTION
… for next tasks

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
There might be many different tasks with different resource requests in a same job, so it does not mean there are no suitable nodes that meet next tasks's requirements when it fails to allocate for one task.

However I have some concerns for this PR:
* It might reduce performance because it will continue to allocate even when next tasks' resource requirement are same with the failed allocated task. Maybe eCache is a way for performance improvement?


There is also a common problem(not sure it is a valid problem :)) I am not sure whether there is a good solution for it: suppose there is a job with 3 tasks for kind A, 4 task of kind B, minMember is 3 which requires 1 task of kind A, and 2 tasks of kind B. For current algorithm, it might allocate 3 tasks of kind A, and find job is ready, then dispatch the job. However the job is not ready actually.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allocate: when failing to allocate for one task, continue to allocate for next tasks.
```

