### PR TITLE
Do graceful eviction using default policy

### DIFF
--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -127,14 +127,9 @@ type defaultEvictor struct {
 }
 
 func (de *defaultEvictor) Evict(p *v1.Pod) error {
-	// TODO (k82cn): makes grace period configurable.
-	threeSecs := int64(3)
-
 	glog.V(3).Infof("Evicting pod %v/%v", p.Namespace, p.Name)
 
-	if err := de.kubeclient.CoreV1().Pods(p.Namespace).Delete(p.Name, &metav1.DeleteOptions{
-		GracePeriodSeconds: &threeSecs,
-	}); err != nil {
+	if err := de.kubeclient.CoreV1().Pods(p.Namespace).Delete(p.Name, nil); err != nil {
 		glog.Errorf("Failed to evict pod <%v/%v>: %#v", p.Namespace, p.Name, err)
 		return err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
According to `k8s.io/kuberentes/pkg/registry/core/pod/strategy.go#CheckGracefulDelete`, if `DeleteOptions` is nil, it will check `pod`'s filed `pod.Spec.TerminationGracePeriodSeconds`. Maybe we could just leave it as nil?

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

