### PR TITLE
Update helm chart version to 0.4.2

### DIFF
--- a/deployment/kube-batch/Chart.yaml
+++ b/deployment/kube-batch/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1alpha1
 description: The batch scheduler of Kubernetes
 name: kube-batch
-version: 0.4.1
+version: 0.4.2


### PR DESCRIPTION
**What this PR does / why we need it**:
Seems helm chart version was not updated to latest version

```release-note
Update helm chart version to 0.4.2
```

