### PR TITLE
Remove unnecessary calculation of priorities for preemption

### DIFF
--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -179,12 +179,9 @@ func preempt(
 
 	allNodes := util.GetNodeList(nodes)
 
-	predicateNodes := util.PredicateNodes(preemptor, allNodes, ssn.PredicateFn)
+	predicatedNodes := util.PredicateNodes(preemptor, allNodes, ssn.PredicateFn)
 
-	nodeScores := util.PrioritizeNodes(preemptor, predicateNodes, ssn.NodeOrderFn)
-
-	selectedNodes := util.SelectBestNode(nodeScores)
-	for _, node := range selectedNodes {
+	for _, node := range predicatedNodes {
 		glog.V(3).Infof("Considering Task <%s/%s> on Node <%s>.",
 			preemptor.Namespace, preemptor.Name, node.Name)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
During preemption step, calculating the priority of each node is not needed. Removing it will improve the performance of `preemption`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```

