### PR TITLE
NodeOrderFn return float value

### DIFF
--- a/pkg/scheduler/api/types.go
+++ b/pkg/scheduler/api/types.go
@@ -104,4 +104,4 @@ type PredicateFn func(*TaskInfo, *NodeInfo) error
 type EvictableFn func(*TaskInfo, []*TaskInfo) []*TaskInfo
 
 // NodeOrderFn is the func declaration used to get priority score for a node for a particular task.
-type NodeOrderFn func(*TaskInfo, *NodeInfo) (int, error)
+type NodeOrderFn func(*TaskInfo, *NodeInfo) (float64, error)

--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -303,8 +303,8 @@ func (ssn *Session) PredicateFn(task *api.TaskInfo, node *api.NodeInfo) error {
 	return nil
 }
 
-func (ssn *Session) NodeOrderFn(task *api.TaskInfo, node *api.NodeInfo) (int, error) {
-	priorityScore := 0
+func (ssn *Session) NodeOrderFn(task *api.TaskInfo, node *api.NodeInfo) (float64, error) {
+	priorityScore := 0.0
 	for _, tier := range ssn.Tiers {
 		for _, plugin := range tier.Plugins {
 			if !isEnabled(plugin.EnabledNodeOrder) {

--- a/pkg/scheduler/util/scheduler_helper.go
+++ b/pkg/scheduler/util/scheduler_helper.go
@@ -54,8 +54,8 @@ func PredicateNodes(task *api.TaskInfo, nodes []*api.NodeInfo, fn api.PredicateF
 }
 
 // PrioritizeNodes returns a map whose key is node's score and value are corresponding nodes
-func PrioritizeNodes(task *api.TaskInfo, nodes []*api.NodeInfo, fn api.NodeOrderFn) map[int][]*api.NodeInfo {
-	nodeScores := map[int][]*api.NodeInfo{}
+func PrioritizeNodes(task *api.TaskInfo, nodes []*api.NodeInfo, fn api.NodeOrderFn) map[float64][]*api.NodeInfo {
+	nodeScores := map[float64][]*api.NodeInfo{}
 
 	var workerLock sync.Mutex
 	scoreNode := func(index int) {
@@ -75,13 +75,13 @@ func PrioritizeNodes(task *api.TaskInfo, nodes []*api.NodeInfo, fn api.NodeOrder
 }
 
 // SelectBestNode returns nodes by order of score
-func SelectBestNode(nodeScores map[int][]*api.NodeInfo) []*api.NodeInfo {
+func SelectBestNode(nodeScores map[float64][]*api.NodeInfo) []*api.NodeInfo {
 	var nodesInorder []*api.NodeInfo
-	var keys []int
+	var keys []float64
 	for key := range nodeScores {
 		keys = append(keys, key)
 	}
-	sort.Sort(sort.Reverse(sort.IntSlice(keys)))
+	sort.Sort(sort.Reverse(sort.Float64Slice(keys)))
 	for _, key := range keys {
 		nodes := nodeScores[key]
 		nodesInorder = append(nodesInorder, nodes...)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
As I said in issue #708, changing the return value of NodeOrderFn from float to int would be better.

The ability of NodeOrderFn remains unchanged now, because functions like leastReq still returns int type and int type could change to float type safely.

But the code after this would benefit from it.
 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #708

**Special notes for your reviewer**:
1. Just change the return value

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

