### PR TITLE
Adding e2e test case for resource limit checks

### DIFF
--- a/test/e2e/predicates.go
+++ b/test/e2e/predicates.go
@@ -17,11 +17,14 @@ limitations under the License.
 package e2e
 
 import (
+	"fmt"
+	"github.com/kubernetes-sigs/kube-batch/pkg/apis/scheduling/v1alpha1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeletapi "k8s.io/kubernetes/pkg/kubelet/apis"
 	schedulerapi "k8s.io/kubernetes/pkg/scheduler/api"
 )
 
@@ -187,6 +190,212 @@ var _ = Describe("Predicates E2E Test", func() {
 		checkError(context, err)
 
 		err = waitPodGroupReady(context, pg)
+		checkError(context, err)
+	})
+
+	// This test verifies we don't allow scheduling of jobs in a way that sum of
+	// limits of tasks is greater than machines capacity.
+
+	It("should validates resource limits of tasks that are allowed to run ", func() {
+		context := initTestContext()
+		defer cleanupTestContext(context)
+
+		// The max cpu available across the nodes
+		nodeMaxAllocatableCpu := int64(0)
+		// The max mem available across the nodes
+		nodeMaxAllocatableMem := int64(0)
+		// Map of available cpu in a node
+		nodeToAllocatableMapCpu := make(map[string]int64)
+		// Map of available mem in a node
+		nodeToAllocatableMemMap := make(map[string]int64)
+		nodeList, err := context.kubeclient.CoreV1().Nodes().List(metav1.ListOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		for _, node := range nodeList.Items {
+			nodeReady := false
+			for _, condition := range node.Status.Conditions {
+				if condition.Type == v1.NodeReady && condition.Status == v1.ConditionTrue {
+					nodeReady = true
+					break
+				}
+			}
+
+			if IsMasterNode(&node) {
+				continue
+			}
+			// Skip the unready node.
+			if !nodeReady {
+				continue
+			}
+			// Find allocatable amount of CPU.
+			allocatable, found := node.Status.Allocatable[v1.ResourceCPU]
+			Expect(found).To(Equal(true))
+			nodeToAllocatableMapCpu[node.Name] = allocatable.MilliValue()
+			if nodeMaxAllocatableCpu < allocatable.MilliValue() {
+				nodeMaxAllocatableCpu = allocatable.MilliValue()
+			}
+
+			// Find allocatable amount of Memory.
+			allocatableMem, found := node.Status.Allocatable[v1.ResourceMemory]
+			Expect(found).To(Equal(true))
+			nodeToAllocatableMemMap[node.Name] = allocatableMem.Value()
+			if nodeMaxAllocatableMem < allocatableMem.Value() {
+				nodeMaxAllocatableMem = allocatableMem.Value()
+			}
+		}
+
+		pods, err := context.kubeclient.CoreV1().Pods(metav1.NamespaceAll).List(metav1.ListOptions{})
+		checkError(context, err)
+		for _, pod := range pods.Items {
+			_, found := nodeToAllocatableMapCpu[pod.Spec.NodeName]
+			_, foundMem := nodeToAllocatableMemMap[pod.Spec.NodeName]
+			if found && foundMem && pod.Status.Phase != v1.PodSucceeded && pod.Status.Phase != v1.PodFailed {
+				nodeToAllocatableMapCpu[pod.Spec.NodeName] -= getRequestedCPU(pod)
+				nodeToAllocatableMemMap[pod.Spec.NodeName] -= getRequestedMemory(pod)
+			}
+		}
+
+		By("Starting Jobs to consume most of the cluster CPU.")
+		// Create a job per node ( i.e with a new podgroup per job).
+		// These jobs will exhaust 70% of the CPU on that node.
+		// Using node-affinity assign the job per node.
+
+		cpuPodGrpList := []*v1alpha1.PodGroup{}
+		for nodeName, cpu := range nodeToAllocatableMapCpu {
+			requestedCPU := cpu * 7 / 10
+			cpuJob := &jobSpec{
+				name: fmt.Sprintf("cpu-filler-job-%s", nodeName),
+				pri:  masterPriority,
+				tasks: []taskSpec{
+					{
+						img: "nginx",
+						req: v1.ResourceList{
+							v1.ResourceCPU: *resource.NewMilliQuantity(requestedCPU, resource.DecimalSI),
+						},
+						min: 1,
+						rep: 1,
+						affinity: &v1.Affinity{
+							NodeAffinity: &v1.NodeAffinity{
+								RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+									NodeSelectorTerms: []v1.NodeSelectorTerm{
+										{
+											MatchExpressions: []v1.NodeSelectorRequirement{
+												{
+													Key:      kubeletapi.LabelHostname,
+													Operator: v1.NodeSelectorOpIn,
+													Values:   []string{nodeName},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			_, cpuPodGroup := createJob(context, cpuJob)
+			cpuPodGrpList = append(cpuPodGrpList, cpuPodGroup)
+		}
+		// Wait for CPU filler jobs to be scheduled.
+		for _, cpuPodGroup := range cpuPodGrpList {
+			err = waitPodGroupReady(context, cpuPodGroup)
+			checkError(context, err)
+		}
+
+		By("Starting Jobs to consume most of the cluster Memory.")
+		// Create a job per node ( i.e with a new podgroup per job).
+		// These jobs will exhaust 70% of the MEM on that node.
+		// Using node-affinity assign the job per node.
+
+		memPodGrpList := []*v1alpha1.PodGroup{}
+		for nodeName, memory := range nodeToAllocatableMemMap {
+			requestedMem := memory * 7 / 10
+			memJob := &jobSpec{
+				name: fmt.Sprintf("mem-filler-job-%s", nodeName),
+				pri:  masterPriority,
+				tasks: []taskSpec{
+					{
+						img: "nginx",
+						req: v1.ResourceList{
+							v1.ResourceMemory: *resource.NewMilliQuantity(requestedMem, resource.DecimalSI),
+						},
+						min: 1,
+						rep: 1,
+						affinity: &v1.Affinity{
+							NodeAffinity: &v1.NodeAffinity{
+								RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+									NodeSelectorTerms: []v1.NodeSelectorTerm{
+										{
+											MatchExpressions: []v1.NodeSelectorRequirement{
+												{
+													Key:      kubeletapi.LabelHostname,
+													Operator: v1.NodeSelectorOpIn,
+													Values:   []string{nodeName},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			_, memPodGroup := createJob(context, memJob)
+			memPodGrpList = append(memPodGrpList, memPodGroup)
+
+		}
+		// Wait for mem filler Jobs to be scheduled.
+		for _, memPod := range memPodGrpList {
+			err = waitPodGroupReady(context, memPod)
+			checkError(context, err)
+		}
+
+		By("Creating another Job that requires unavailable amount of CPU.")
+		// Create another Job that requires 50% of the largest node CPU resources.
+		// This Job should remain pending as at least 70% of CPU of other nodes in
+		// the cluster are already consumed.
+
+		addCpuJob := &jobSpec{
+			name: "additional-job-cpu",
+			pri:  masterPriority,
+			tasks: []taskSpec{
+				{
+					img: "nginx",
+					req: v1.ResourceList{
+						v1.ResourceCPU: *resource.NewMilliQuantity(((nodeMaxAllocatableCpu * 5) / 10), resource.DecimalSI),
+					},
+					min: 1,
+					rep: 1,
+				},
+			},
+		}
+		_, addCpuPodGroup := createJob(context, addCpuJob)
+		// this additional-job-cpu should be pending
+		err = waitPodGroupPending(context, addCpuPodGroup)
+		checkError(context, err)
+
+		By("Creating another Job that requires unavailable amount of Memory.")
+		// Create another Job that requires 50% of the largest node Memory resources.
+		// This Job should remain pending as at least 70% of Memory of other nodes in
+		// the cluster are already consumed.
+		addMemJob := &jobSpec{
+			name: "additional-job-mem",
+			pri:  masterPriority,
+			tasks: []taskSpec{
+				{
+					img: "nginx",
+					req: v1.ResourceList{
+						v1.ResourceMemory: *resource.NewMilliQuantity(((nodeMaxAllocatableCpu * 5) / 10), resource.DecimalSI),
+					},
+					min: 1,
+					rep: 1,
+				},
+			},
+		}
+		_, addMemPodGroup := createJob(context, addMemJob)
+		// This additional-job-mem should be pending
+		err = waitPodGroupPending(context, addMemPodGroup)
 		checkError(context, err)
 	})
 

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -46,7 +46,7 @@ import (
 	kbapi "github.com/kubernetes-sigs/kube-batch/pkg/scheduler/api"
 )
 
-var oneMinute = 1 * time.Minute
+var oneMinute = 5 * time.Minute
 
 var halfCPU = v1.ResourceList{"cpu": resource.MustParse("500m")}
 var oneCPU = v1.ResourceList{"cpu": resource.MustParse("1000m")}
@@ -815,4 +815,31 @@ func preparePatchBytesforNode(nodeName string, oldNode *v1.Node, newNode *v1.Nod
 	}
 
 	return patchBytes, nil
+}
+
+func getRequestedCPU(pod v1.Pod) int64 {
+	var result int64
+	for _, container := range pod.Spec.Containers {
+		result += container.Resources.Requests.Cpu().MilliValue()
+	}
+	return result
+}
+
+func getRequestedMemory(pod v1.Pod) int64 {
+	var result int64
+	for _, container := range pod.Spec.Containers {
+		result += container.Resources.Requests.Memory().Value()
+	}
+	return result
+}
+
+// IsMasterNode returns true if its a master node or false otherwise.
+func IsMasterNode(node *v1.Node) bool {
+
+	for _, taint := range node.Spec.Taints {
+		if taint.Key == "node-role.kubernetes.io/master" {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Added a new test case to check the resource limit calculation by the scheduler.
This test creates multiple podgroups and exhausts the cluster resource and then tries to create other podgroups which will stay unscheduled.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
#591 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

