### PR TITLE
Adding e2e test case to check if the scheduler respects maxpods limit…

### DIFF
--- a/test/e2e/nodeorder.go
+++ b/test/e2e/nodeorder.go
@@ -30,7 +30,7 @@ var _ = Describe("NodeOrder E2E Test", func() {
 		context := initTestContext()
 		defer cleanupTestContext(context)
 
-		nodeNames := getAllWorkerNodes(context)
+		nodeNames := getAllWorkerNodeNames(context)
 		var preferredSchedulingTermSlice []v1.PreferredSchedulingTerm
 		nodeSelectorRequirement := v1.NodeSelectorRequirement{Key: kubeletapi.LabelHostname, Operator: v1.NodeSelectorOpIn, Values: []string{nodeNames[0]}}
 		nodeSelectorTerm := v1.NodeSelectorTerm{MatchExpressions: []v1.NodeSelectorRequirement{nodeSelectorRequirement}}
@@ -139,7 +139,7 @@ var _ = Describe("NodeOrder E2E Test", func() {
 		context := initTestContext()
 		defer cleanupTestContext(context)
 
-		nodeNames := getAllWorkerNodes(context)
+		nodeNames := getAllWorkerNodeNames(context)
 		affinityNodeOne := &v1.Affinity{
 			NodeAffinity: &v1.NodeAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{

--- a/test/e2e/predicates.go
+++ b/test/e2e/predicates.go
@@ -17,11 +17,14 @@ limitations under the License.
 package e2e
 
 import (
+	"fmt"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeletapi "k8s.io/kubernetes/pkg/kubelet/apis"
 	schedulerapi "k8s.io/kubernetes/pkg/scheduler/api"
 )
 
@@ -190,4 +193,117 @@ var _ = Describe("Predicates E2E Test", func() {
 		checkError(context, err)
 	})
 
+	// Description: This test is to validate if the scheduler respects the max-pods limit of a node.
+	// steps:
+	// 1) Fetch a node from the list of available node.
+	// 2) Get the nodes max-pods limit.
+	// 3) Check nodes stability and get the pods running on that node.
+	// 4) From the max-pods limit and the total pods runnnin from (2) and (3) we can calculate how many pods we can create.
+	// 5) Create the remaining pods as a podgroup and deploy.
+	// 6) Now create a single podgroup called pending and create one task with one replica [pod], this will remain in
+	//    pending state since we have exhausted all the max pods limit.
+	//
+	It("validates MaxPods limit [Slow]", func() {
+		context := initTestContext()
+		defer func() {
+
+			// need to make sure if the namespace is delete properly.
+			// this takes time for this test case since we create lot may pods in podgroup
+			cleanupTestContext(context)
+		}()
+
+		var totalPodCapacity int64
+		var podsNeededForSaturation int32
+		schedulableNodes := getAllWorkerNodes(context)
+		nodeName := schedulableNodes[0].Name
+
+		// get the max-pods capicity
+		podCapacity, found := schedulableNodes[0].Status.Capacity[v1.ResourcePods]
+		Expect(found).To(Equal(true))
+		totalPodCapacity = podCapacity.Value()
+		currentlyScheduledPods := getScheduledPodsOfNode(context, nodeName)
+		podsNeededForSaturation = int32(totalPodCapacity) - int32(currentlyScheduledPods)
+		if podsNeededForSaturation > 0 {
+			// create a podgroup with nodeselector to the node and the number of replicas
+			// in the task as podsNeededForSaturation
+
+			affinityNode := &v1.Affinity{
+				NodeAffinity: &v1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+						NodeSelectorTerms: []v1.NodeSelectorTerm{
+							{
+								MatchExpressions: []v1.NodeSelectorRequirement{
+									{
+										Key:      kubeletapi.LabelHostname,
+										Operator: v1.NodeSelectorOpIn,
+										Values:   []string{nodeName},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			maxpodJobOne := &jobSpec{
+				name: "max-pods",
+				tasks: []taskSpec{
+					{
+						img:      "nginx",
+						min:      podsNeededForSaturation,
+						rep:      podsNeededForSaturation,
+						affinity: affinityNode,
+					},
+				},
+			}
+
+			//Schedule Job in the selected Node
+			By(fmt.Sprintf("Creating the PodGroup with %v task replicas on node %v", podsNeededForSaturation, nodeName))
+			_, maxpodspg := createJob(context, maxpodJobOne)
+			By("Waiting for the PodGroup to have running status")
+			err := waitTimeoutPodGroupReady(context, maxpodspg, fiveMinutes)
+			checkError(context, err)
+
+		}
+		// create the new podgroup with on task replica on the same node as created before.
+		// this podgroup should remain pending
+		affinityNode := &v1.Affinity{
+			NodeAffinity: &v1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+					NodeSelectorTerms: []v1.NodeSelectorTerm{
+						{
+							MatchExpressions: []v1.NodeSelectorRequirement{
+								{
+									Key:      kubeletapi.LabelHostname,
+									Operator: v1.NodeSelectorOpIn,
+									Values:   []string{nodeName},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		maxpodJobTwo := &jobSpec{
+			name: "unscheduled-pod",
+			tasks: []taskSpec{
+				{
+					img:      "nginx",
+					min:      1,
+					rep:      1,
+					affinity: affinityNode,
+				},
+			},
+		}
+
+		//Schedule Job in the selected Node
+		By("Creating the PodGroup with one task replicas")
+		_, pendingpg := createJob(context, maxpodJobTwo)
+		By("Waiting for the PodGroup status to remain pending")
+		err := waitTimeoutPodGroupReady(context, pendingpg, oneMinute)
+		if err != wait.ErrWaitTimeout {
+			checkError(context, err)
+		}
+
+	})
 })

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -27,6 +27,10 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	kbv1 "github.com/kubernetes-sigs/kube-batch/pkg/apis/scheduling/v1alpha1"
+	kbver "github.com/kubernetes-sigs/kube-batch/pkg/client/clientset/versioned"
+	kbapi "github.com/kubernetes-sigs/kube-batch/pkg/scheduler/api"
+
 	appv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/api/core/v1"
@@ -40,13 +44,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
-
-	kbv1 "github.com/kubernetes-sigs/kube-batch/pkg/apis/scheduling/v1alpha1"
-	kbver "github.com/kubernetes-sigs/kube-batch/pkg/client/clientset/versioned"
-	kbapi "github.com/kubernetes-sigs/kube-batch/pkg/scheduler/api"
 )
 
-var oneMinute = 1 * time.Minute
+const (
+	oneMinute   = 1 * time.Minute
+	fiveMinutes = 5 * time.Minute
+)
 
 var halfCPU = v1.ResourceList{"cpu": resource.MustParse("500m")}
 var oneCPU = v1.ResourceList{"cpu": resource.MustParse("1000m")}
@@ -156,8 +159,9 @@ func cleanupTestContext(cxt *context) {
 	})
 	checkError(cxt, err)
 
-	// Wait for namespace deleted.
-	err = wait.Poll(100*time.Millisecond, oneMinute, namespaceNotExist(cxt))
+	// wait for namespace to delete or timeout.
+	err = wait.Poll(1*time.Second, 10*time.Minute, namespaceNotExist(cxt))
+
 	checkError(cxt, err)
 }
 
@@ -437,6 +441,17 @@ func podGroupEvicted(ctx *context, pg *kbv1.PodGroup, time time.Time) wait.Condi
 
 		return false, nil
 	}
+}
+
+// waits the 'timeout' specified duration to check if the PodGroup is ready
+func waitTimeoutPodGroupReady(ctx *context, pg *kbv1.PodGroup, timeout time.Duration) error {
+	return waitTimeoutTasksReady(ctx, pg, int(pg.Spec.MinMember), timeout)
+}
+
+// waits the 'timeout' specified duration to check if the tasks are ready
+func waitTimeoutTasksReady(ctx *context, pg *kbv1.PodGroup, taskNum int, timeout time.Duration) error {
+	return wait.Poll(100*time.Millisecond, timeout, taskPhase(ctx, pg,
+		[]v1.PodPhase{v1.PodRunning, v1.PodSucceeded}, taskNum))
 }
 
 func waitPodGroupReady(ctx *context, pg *kbv1.PodGroup) error {
@@ -783,18 +798,43 @@ func removeTaintsFromAllNodes(ctx *context, taints []v1.Taint) error {
 	return nil
 }
 
-func getAllWorkerNodes(ctx *context) []string {
-	nodeNames := make([]string, 0)
+// this method will return only worker nodes that are ready ignoring all other node including the master node
+func getAllWorkerNodes(ctx *context) []*v1.Node {
+	workernodes := make([]*v1.Node, 0)
 
 	nodes, err := ctx.kubeclient.CoreV1().Nodes().List(metav1.ListOptions{})
 	checkError(ctx, err)
 
-	for _, node := range nodes.Items {
-		if len(node.Spec.Taints) != 0 {
+	for i, node := range nodes.Items {
+		nodeReady := false
+		for _, condition := range node.Status.Conditions {
+			if condition.Type == v1.NodeReady && condition.Status == v1.ConditionTrue {
+				nodeReady = true
+				break
+			}
+		}
+		if IsMasterNode(&node) {
 			continue
 		}
+		// Skip the unready node.
+		if !nodeReady {
+			continue
+		}
+		workernodes = append(workernodes, &nodes.Items[i])
+	}
+	return workernodes
+}
+
+// this method will return only worker nodes names that are ready ignoring all other node including the master node
+func getAllWorkerNodeNames(ctx *context) []string {
+
+	nodeNames := make([]string, 0)
+	nodes := getAllWorkerNodes(ctx)
+
+	for _, node := range nodes {
 		nodeNames = append(nodeNames, node.Name)
 	}
+
 	return nodeNames
 }
 
@@ -815,4 +855,64 @@ func preparePatchBytesforNode(nodeName string, oldNode *v1.Node, newNode *v1.Nod
 	}
 
 	return patchBytes, nil
+}
+
+// IsMasterNode returns true if its a master node or false otherwise.
+func IsMasterNode(node *v1.Node) bool {
+
+	for _, taint := range node.Spec.Taints {
+		if taint.Key == "node-role.kubernetes.io/master" {
+			return true
+		}
+	}
+	return false
+}
+
+// getScheduledPodsOfNode will return a list of pods
+// which are in running condition
+// and ignore the pods which have completed/failed/succeeded
+// If a pod status shows scheduled but the node-name is not assigned wait for the
+// pod to get scheduled
+// we consider only running pods
+
+func getScheduledPodsOfNode(ctx *context, nodeName string) int {
+	allPods, err := ctx.kubeclient.CoreV1().Pods(metav1.NamespaceAll).List(metav1.ListOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	// API server returns also Pods that succeeded. We need to filter them out.
+	currentPods := make([]v1.Pod, 0, len(allPods.Items))
+	for _, pod := range allPods.Items {
+		if pod.Status.Phase != v1.PodSucceeded && pod.Status.Phase != v1.PodFailed && pod.Spec.NodeName == nodeName {
+			currentPods = append(currentPods, pod)
+		}
+	}
+	allPods.Items = currentPods
+	scheduledPods := GetPodsScheduled(allPods, nodeName)
+
+	return len(scheduledPods)
+}
+
+// GetPodsScheduled returns a number of currently scheduled Pods.
+func GetPodsScheduled(pods *v1.PodList, nodeName string) (scheduledPods []v1.Pod) {
+	for _, pod := range pods.Items {
+		_, scheduledCondition := GetPodCondition(&pod.Status, v1.PodScheduled)
+		Expect(scheduledCondition != nil).To(Equal(true))
+		Expect(scheduledCondition.Status).To(Equal(v1.ConditionTrue))
+		scheduledPods = append(scheduledPods, pod)
+	}
+
+	return
+}
+
+// GetPodCondition extracts the provided condition from the given list of condition and
+// returns the index of the condition and the condition. Returns -1 and nil if the condition is not present.
+func GetPodCondition(status *v1.PodStatus, conditionType v1.PodConditionType) (int, *v1.PodCondition) {
+	if status == nil || status.Conditions == nil {
+		return -1, nil
+	}
+	for i := range status.Conditions {
+		if status.Conditions[i].Type == conditionType {
+			return i, &status.Conditions[i]
+		}
+	}
+	return -1, nil
 }


### PR DESCRIPTION
… of a given node

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR adds a E2E test to check if scheduler respects the max-pods limit of a given node.



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
#591

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

