### PR TITLE
[Add Job Resource] Fix panic error when running job e2e tests

### DIFF
--- a/pkg/controllers/apis/job_info.go
+++ b/pkg/controllers/apis/job_info.go
@@ -35,6 +35,26 @@ type JobInfo struct {
 	Pods map[string]map[string]*v1.Pod
 }
 
+// Clone jobInfo object
+func (ji *JobInfo) Clone() *JobInfo {
+	job := &JobInfo{
+		Namespace: ji.Namespace,
+		Name:      ji.Name,
+		Job:       ji.Job,
+
+		Pods: make(map[string]map[string]*v1.Pod),
+	}
+
+	for key, pods := range ji.Pods {
+		job.Pods[key] = make(map[string]*v1.Pod)
+		for pn, pod := range pods {
+			job.Pods[key][pn] = pod
+		}
+	}
+
+	return job
+}
+
 // SetJob is used to set job
 func (ji *JobInfo) SetJob(job *v1alpha1.Job) {
 	ji.Name = job.Name

--- a/pkg/controllers/cache/cache.go
+++ b/pkg/controllers/cache/cache.go
@@ -91,7 +91,7 @@ func (jc *jobCache) Get(key string) (*apis.JobInfo, error) {
 		return nil, fmt.Errorf("job <%s> is not ready", key)
 	}
 
-	return job, nil
+	return job.Clone(), nil
 }
 
 // GetStatus returns job status


### PR DESCRIPTION
**What this PR does / why we need it**:

Job object will be directly used outside of cache and it will cause none pointer error when it's been used in one thread while been deleted in anothe. Adding it back.

