### PR TITLE
Migrate duplicated code in nodeorder and predicate plugin

### DIFF
--- a/pkg/scheduler/plugins/nodeorder/nodeorder.go
+++ b/pkg/scheduler/plugins/nodeorder/nodeorder.go
@@ -22,14 +22,13 @@ import (
 	"github.com/golang/glog"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/kubernetes/pkg/scheduler/algorithm"
 	"k8s.io/kubernetes/pkg/scheduler/algorithm/priorities"
 	schedulerapi "k8s.io/kubernetes/pkg/scheduler/api"
 	"k8s.io/kubernetes/pkg/scheduler/cache"
 
 	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler/api"
 	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler/framework"
+	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler/plugins/util"
 )
 
 const (
@@ -89,72 +88,6 @@ func (c *cachedNodeInfo) GetNodeInfo(name string) (*v1.Node, error) {
 	}
 
 	return node.Node, nil
-}
-
-type podLister struct {
-	session *framework.Session
-}
-
-func (pl *podLister) List(selector labels.Selector) ([]*v1.Pod, error) {
-	var pods []*v1.Pod
-	for _, job := range pl.session.Jobs {
-		for status, tasks := range job.TaskStatusIndex {
-			if !api.AllocatedStatus(status) {
-				continue
-			}
-
-			for _, task := range tasks {
-				if selector.Matches(labels.Set(task.Pod.Labels)) {
-					if task.NodeName != task.Pod.Spec.NodeName {
-						pod := task.Pod.DeepCopy()
-						pod.Spec.NodeName = task.NodeName
-						pods = append(pods, pod)
-					} else {
-						pods = append(pods, task.Pod)
-					}
-				}
-			}
-		}
-	}
-
-	return pods, nil
-}
-
-func (pl *podLister) FilteredList(podFilter algorithm.PodFilter, selector labels.Selector) ([]*v1.Pod, error) {
-	var pods []*v1.Pod
-	for _, job := range pl.session.Jobs {
-		for status, tasks := range job.TaskStatusIndex {
-			if !api.AllocatedStatus(status) {
-				continue
-			}
-
-			for _, task := range tasks {
-				if podFilter(task.Pod) && selector.Matches(labels.Set(task.Pod.Labels)) {
-					if task.NodeName != task.Pod.Spec.NodeName {
-						pod := task.Pod.DeepCopy()
-						pod.Spec.NodeName = task.NodeName
-						pods = append(pods, pod)
-					} else {
-						pods = append(pods, task.Pod)
-					}
-				}
-			}
-		}
-	}
-
-	return pods, nil
-}
-
-type nodeLister struct {
-	session *framework.Session
-}
-
-func (nl *nodeLister) List() ([]*v1.Node, error) {
-	var nodes []*v1.Node
-	for _, node := range nl.session.Nodes {
-		nodes = append(nodes, node.Node)
-	}
-	return nodes, nil
 }
 
 //New function returns prioritizePlugin object
@@ -224,12 +157,12 @@ func (pp *nodeOrderPlugin) OnSessionOpen(ssn *framework.Session) {
 
 		weight := calculateWeight(pp.pluginArguments)
 
-		pl := &podLister{
-			session: ssn,
+		pl := &util.PodLister{
+			Session: ssn,
 		}
 
-		nl := &nodeLister{
-			session: ssn,
+		nl := &util.NodeLister{
+			Session: ssn,
 		}
 
 		cn := &cachedNodeInfo{

--- a/pkg/scheduler/plugins/predicates/predicates.go
+++ b/pkg/scheduler/plugins/predicates/predicates.go
@@ -22,14 +22,13 @@ import (
 
 	"github.com/golang/glog"
 
-	"k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/kubernetes/pkg/scheduler/algorithm"
 	"k8s.io/kubernetes/pkg/scheduler/algorithm/predicates"
 	"k8s.io/kubernetes/pkg/scheduler/cache"
 
 	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler/api"
 	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler/framework"
+	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler/plugins/util"
 )
 
 type predicatesPlugin struct {
@@ -46,65 +45,6 @@ func (pp *predicatesPlugin) Name() string {
 	return "predicates"
 }
 
-type podLister struct {
-	session *framework.Session
-}
-
-func (pl *podLister) List(selector labels.Selector) ([]*v1.Pod, error) {
-	var pods []*v1.Pod
-	for _, job := range pl.session.Jobs {
-		for status, tasks := range job.TaskStatusIndex {
-			if !api.AllocatedStatus(status) {
-				continue
-			}
-
-			for _, task := range tasks {
-				if selector.Matches(labels.Set(task.Pod.Labels)) {
-					pod := task.Pod.DeepCopy()
-					pod.Spec.NodeName = task.NodeName
-					pods = append(pods, pod)
-				}
-			}
-		}
-	}
-
-	return pods, nil
-}
-
-func (pl *podLister) FilteredList(podFilter algorithm.PodFilter, selector labels.Selector) ([]*v1.Pod, error) {
-	var pods []*v1.Pod
-	for _, job := range pl.session.Jobs {
-		for status, tasks := range job.TaskStatusIndex {
-			if !api.AllocatedStatus(status) {
-				continue
-			}
-
-			for _, task := range tasks {
-				if podFilter(task.Pod) && selector.Matches(labels.Set(task.Pod.Labels)) {
-					pod := task.Pod.DeepCopy()
-					pod.Spec.NodeName = task.NodeName
-					pods = append(pods, pod)
-				}
-			}
-		}
-	}
-
-	return pods, nil
-}
-
-type cachedNodeInfo struct {
-	session *framework.Session
-}
-
-func (c *cachedNodeInfo) GetNodeInfo(name string) (*v1.Node, error) {
-	node, found := c.session.Nodes[name]
-	if !found {
-		return nil, fmt.Errorf("failed to find node <%s>", name)
-	}
-
-	return node.Node, nil
-}
-
 func formatReason(reasons []algorithm.PredicateFailureReason) string {
 	reasonStrings := []string{}
 	for _, v := range reasons {
@@ -115,12 +55,12 @@ func formatReason(reasons []algorithm.PredicateFailureReason) string {
 }
 
 func (pp *predicatesPlugin) OnSessionOpen(ssn *framework.Session) {
-	pl := &podLister{
-		session: ssn,
+	pl := &util.PodLister{
+		Session: ssn,
 	}
 
-	ni := &cachedNodeInfo{
-		session: ssn,
+	ni := &util.CachedNodeInfo{
+		Session: ssn,
 	}
 
 	ssn.AddPredicateFn(pp.Name(), func(task *api.TaskInfo, node *api.NodeInfo) error {

--- a/pkg/scheduler/plugins/util/util.go
+++ b/pkg/scheduler/plugins/util/util.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/kubernetes/pkg/scheduler/algorithm"
+
+	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler/api"
+	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler/framework"
+)
+
+// PodLister is used in predicate and nodeorder plugin
+type PodLister struct {
+	Session *framework.Session
+}
+
+// List method is used to list all the pods
+func (pl *PodLister) List(selector labels.Selector) ([]*v1.Pod, error) {
+	var pods []*v1.Pod
+	for _, job := range pl.Session.Jobs {
+		for status, tasks := range job.TaskStatusIndex {
+			if !api.AllocatedStatus(status) {
+				continue
+			}
+
+			for _, task := range tasks {
+				if selector.Matches(labels.Set(task.Pod.Labels)) {
+					if task.NodeName != task.Pod.Spec.NodeName {
+						pod := task.Pod.DeepCopy()
+						pod.Spec.NodeName = task.NodeName
+						pods = append(pods, pod)
+					} else {
+						pods = append(pods, task.Pod)
+					}
+				}
+			}
+		}
+	}
+
+	return pods, nil
+}
+
+// FilteredList is used to list all the pods under filter condition
+func (pl *PodLister) FilteredList(podFilter algorithm.PodFilter, selector labels.Selector) ([]*v1.Pod, error) {
+	var pods []*v1.Pod
+	for _, job := range pl.Session.Jobs {
+		for status, tasks := range job.TaskStatusIndex {
+			if !api.AllocatedStatus(status) {
+				continue
+			}
+
+			for _, task := range tasks {
+				if podFilter(task.Pod) && selector.Matches(labels.Set(task.Pod.Labels)) {
+					if task.NodeName != task.Pod.Spec.NodeName {
+						pod := task.Pod.DeepCopy()
+						pod.Spec.NodeName = task.NodeName
+						pods = append(pods, pod)
+					} else {
+						pods = append(pods, task.Pod)
+					}
+				}
+			}
+		}
+	}
+
+	return pods, nil
+}
+
+// CachedNodeInfo is used in nodeorder and predicate plugin
+type CachedNodeInfo struct {
+	Session *framework.Session
+}
+
+// GetNodeInfo is used to get info of a particular node
+func (c *CachedNodeInfo) GetNodeInfo(name string) (*v1.Node, error) {
+	node, found := c.Session.Nodes[name]
+	if !found {
+		return nil, fmt.Errorf("failed to find node <%s>", name)
+	}
+
+	return node.Node, nil
+}
+
+// NodeLister is used in nodeorder plugin
+type NodeLister struct {
+	Session *framework.Session
+}
+
+// List is used to list all the nodes
+func (nl *NodeLister) List() ([]*v1.Node, error) {
+	var nodes []*v1.Node
+	for _, node := range nl.Session.Nodes {
+		nodes = append(nodes, node.Node)
+	}
+	return nodes, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Move duplicated code of nodeorder and predicate plugin to util directory
**Which issue(s) this PR fixes**
https://github.com/kubernetes-sigs/kube-batch/issues/814