### PR TITLE
Adding max-pods test case under kube-batch e2e test cases

### DIFF
--- a/test/e2e/kube-batch/predicates.go
+++ b/test/e2e/kube-batch/predicates.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube_batch
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	kubeletapi "k8s.io/kubernetes/pkg/kubelet/apis"
+)
+
+var _ = Describe("Predicates E2E Test", func() {
+
+	// Description: This test is to validate if the scheduler respects the max-pods limit of a node.
+	// steps:
+	// 1) Fetch a node from the list of available node.
+	// 2) Get the nodes max-pods limit.
+	// 3) Check nodes stability and get the pods running on that node.
+	// 4) From the max-pods limit and the total pods runnnin from (2) and (3) we can calculate how many pods we can create.
+	// 5) Create the remaining pods as a podgroup and deploy.
+	// 6) Now create a single podgroup called pending and create one task with one replica [pod], this will remain in
+	//    pending state since we have exhausted all the max pods limit.
+	//
+	It("validates MaxPods limit [Slow]", func() {
+		context := initTestContext()
+		defer func() {
+
+			// need to make sure if the namespace is delete properly.
+			// this takes time for this test case since we create lot may pods in podgroup
+			cleanupTestContext(context)
+		}()
+
+		var totalPodCapacity int64
+		var podsNeededForSaturation int32
+		schedulableNodes := getAllWorkerNodes(context)
+		nodeName := schedulableNodes[0].Name
+
+		// get the max-pods capicity
+		podCapacity, found := schedulableNodes[0].Status.Capacity[v1.ResourcePods]
+		Expect(found).To(Equal(true))
+		totalPodCapacity = podCapacity.Value()
+		currentlyScheduledPods := getScheduledPodsOfNode(context, nodeName)
+		podsNeededForSaturation = int32(totalPodCapacity) - int32(currentlyScheduledPods)
+		if podsNeededForSaturation > 0 {
+			// create a podgroup with nodeselector to the node and the number of replicas
+			// in the task as podsNeededForSaturation
+
+			affinityNode := &v1.Affinity{
+				NodeAffinity: &v1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+						NodeSelectorTerms: []v1.NodeSelectorTerm{
+							{
+								MatchExpressions: []v1.NodeSelectorRequirement{
+									{
+										Key:      kubeletapi.LabelHostname,
+										Operator: v1.NodeSelectorOpIn,
+										Values:   []string{nodeName},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			maxpodJobOne := &jobSpec{
+				name: "max-pods",
+				tasks: []taskSpec{
+					{
+						img:      "nginx",
+						min:      podsNeededForSaturation,
+						rep:      podsNeededForSaturation,
+						affinity: affinityNode,
+					},
+				},
+			}
+
+			//Schedule Job in the selected Node
+			By(fmt.Sprintf("Creating the PodGroup with %v task replicas on node %v", podsNeededForSaturation, nodeName))
+			_, maxpodspg := createJob(context, maxpodJobOne)
+			By("Waiting for the PodGroup to have running status")
+			err := waitTimeoutPodGroupReady(context, maxpodspg, tenMinute)
+			checkError(context, err)
+
+		}
+		// create the new podgroup with on task replica on the same node as created before.
+		// this podgroup should remain pending
+		affinityNode := &v1.Affinity{
+			NodeAffinity: &v1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+					NodeSelectorTerms: []v1.NodeSelectorTerm{
+						{
+							MatchExpressions: []v1.NodeSelectorRequirement{
+								{
+									Key:      kubeletapi.LabelHostname,
+									Operator: v1.NodeSelectorOpIn,
+									Values:   []string{nodeName},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		maxpodJobTwo := &jobSpec{
+			name: "unscheduled-pod",
+			tasks: []taskSpec{
+				{
+					img:      "nginx",
+					min:      1,
+					rep:      1,
+					affinity: affinityNode,
+				},
+			},
+		}
+
+		//Schedule Job in the selected Node
+		By("Creating the PodGroup with one task replicas")
+		_, pendingpg := createJob(context, maxpodJobTwo)
+		By("Waiting for the PodGroup status to remain pending")
+		err := waitTimeoutPodGroupReady(context, pendingpg, oneMinute)
+		if err != wait.ErrWaitTimeout {
+			checkError(context, err)
+		}
+
+	})
+})

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -167,7 +167,7 @@ func cleanupTestContext(cxt *context) {
 	checkError(cxt, err)
 
 	// Wait for namespace deleted.
-	err = wait.Poll(100*time.Millisecond, oneMinute, namespaceNotExist(cxt))
+	err = wait.Poll(100*time.Millisecond, tenMinute, namespaceNotExist(cxt))
 	checkError(cxt, err)
 }
 
@@ -447,6 +447,17 @@ func podGroupEvicted(ctx *context, pg *kbv1.PodGroup, time time.Time) wait.Condi
 
 		return false, nil
 	}
+}
+
+// waits the 'timeout' specified duration to check if the PodGroup is ready
+func waitTimeoutPodGroupReady(ctx *context, pg *kbv1.PodGroup, timeout time.Duration) error {
+	return waitTimeoutTasksReady(ctx, pg, int(pg.Spec.MinMember), timeout)
+}
+
+// waits the 'timeout' specified duration to check if the tasks are ready
+func waitTimeoutTasksReady(ctx *context, pg *kbv1.PodGroup, taskNum int, timeout time.Duration) error {
+	return wait.Poll(100*time.Millisecond, timeout, taskPhase(ctx, pg,
+		[]v1.PodPhase{v1.PodRunning, v1.PodSucceeded}, taskNum))
 }
 
 func waitPodGroupReady(ctx *context, pg *kbv1.PodGroup) error {
@@ -793,18 +804,43 @@ func removeTaintsFromAllNodes(ctx *context, taints []v1.Taint) error {
 	return nil
 }
 
-func getAllWorkerNodes(ctx *context) []string {
-	nodeNames := make([]string, 0)
+// this method will return only worker nodes that are ready ignoring all other node including the master node
+func getAllWorkerNodes(ctx *context) []*v1.Node {
+	workernodes := make([]*v1.Node, 0)
 
 	nodes, err := ctx.kubeclient.CoreV1().Nodes().List(metav1.ListOptions{})
 	checkError(ctx, err)
 
-	for _, node := range nodes.Items {
-		if len(node.Spec.Taints) != 0 {
+	for i, node := range nodes.Items {
+		nodeReady := false
+		for _, condition := range node.Status.Conditions {
+			if condition.Type == v1.NodeReady && condition.Status == v1.ConditionTrue {
+				nodeReady = true
+				break
+			}
+		}
+		if IsMasterNode(&node) {
 			continue
 		}
+		// Skip the unready node.
+		if !nodeReady {
+			continue
+		}
+		workernodes = append(workernodes, &nodes.Items[i])
+	}
+	return workernodes
+}
+
+// this method will return only worker nodes names that are ready ignoring all other node including the master node
+func getAllWorkerNodeNames(ctx *context) []string {
+
+	nodeNames := make([]string, 0)
+	nodes := getAllWorkerNodes(ctx)
+
+	for _, node := range nodes {
 		nodeNames = append(nodeNames, node.Name)
 	}
+
 	return nodeNames
 }
 
@@ -1025,4 +1061,64 @@ func deleteReplicationController(ctx *context, name string) error {
 	return ctx.kubeclient.CoreV1().ReplicationControllers(ctx.namespace).Delete(name, &metav1.DeleteOptions{
 		PropagationPolicy: &foreground,
 	})
+}
+
+// IsMasterNode returns true if its a master node or false otherwise.
+func IsMasterNode(node *v1.Node) bool {
+
+	for _, taint := range node.Spec.Taints {
+		if taint.Key == "node-role.kubernetes.io/master" {
+			return true
+		}
+	}
+	return false
+}
+
+// getScheduledPodsOfNode will return a list of pods
+// which are in running condition
+// and ignore the pods which have completed/failed/succeeded
+// If a pod status shows scheduled but the node-name is not assigned wait for the
+// pod to get scheduled
+// we consider only running pods
+
+func getScheduledPodsOfNode(ctx *context, nodeName string) int {
+	allPods, err := ctx.kubeclient.CoreV1().Pods(metav1.NamespaceAll).List(metav1.ListOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	// API server returns also Pods that succeeded. We need to filter them out.
+	currentPods := make([]v1.Pod, 0, len(allPods.Items))
+	for _, pod := range allPods.Items {
+		if pod.Status.Phase != v1.PodSucceeded && pod.Status.Phase != v1.PodFailed && pod.Spec.NodeName == nodeName {
+			currentPods = append(currentPods, pod)
+		}
+	}
+	allPods.Items = currentPods
+	scheduledPods := GetPodsScheduled(allPods, nodeName)
+
+	return len(scheduledPods)
+}
+
+// GetPodsScheduled returns a number of currently scheduled Pods.
+func GetPodsScheduled(pods *v1.PodList, nodeName string) (scheduledPods []v1.Pod) {
+	for _, pod := range pods.Items {
+		_, scheduledCondition := GetPodCondition(&pod.Status, v1.PodScheduled)
+		Expect(scheduledCondition != nil).To(Equal(true))
+		Expect(scheduledCondition.Status).To(Equal(v1.ConditionTrue))
+		scheduledPods = append(scheduledPods, pod)
+	}
+
+	return
+}
+
+// GetPodCondition extracts the provided condition from the given list of condition and
+// returns the index of the condition and the condition. Returns -1 and nil if the condition is not present.
+func GetPodCondition(status *v1.PodStatus, conditionType v1.PodConditionType) (int, *v1.PodCondition) {
+	if status == nil || status.Conditions == nil {
+		return -1, nil
+	}
+	for i := range status.Conditions {
+		if status.Conditions[i].Type == conditionType {
+			return i, &status.Conditions[i]
+		}
+	}
+	return -1, nil
 }


### PR DESCRIPTION
Adding test cases for max-pods checks under the kube-batch e2e test cases.

refer PR #748 

To be merged after the PR #825 

/assign @TommyLike 