### PR TITLE
Fixed the Pod failure event reason string for the k8s conformance tes…

### DIFF
--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -464,7 +464,10 @@ func (sc *SchedulerCache) taskUnschedulable(task *api.TaskInfo, message string) 
 
 	pod := task.Pod.DeepCopy()
 
-	sc.Recorder.Eventf(pod, v1.EventTypeWarning, string(v1.PodReasonUnschedulable), message)
+	// The reason field in 'Events' should be "FailedScheduling", there is not constants defined for this in
+	// k8s core, so using the same string here.
+	// The reason field in PodCondition should be "Unschedulable"
+	sc.Recorder.Eventf(pod, v1.EventTypeWarning, "FailedScheduling", message)
 	if _, err := sc.StatusUpdater.UpdatePodCondition(pod, &v1.PodCondition{
 		Type:    v1.PodScheduled,
 		Status:  v1.ConditionFalse,


### PR DESCRIPTION
Refer #829 

The expected reason from the events in k8s confromance test was not matching kube-batch's events reason.

The expected was 'FailedScheduling' but kube-batch was sending 'Unschedulable' as the reason
for the task failure.

So the fix is to use the right event reason for the task failures.
Also note the Events reson for the PodGroup success/failure needs no modification.
Since that's a 'kube-batch' defined object and we can have our custom events reason and message string.


This fix resolves the following two test case failure in k8s conformance test.


```
root1@root1-HP-EliteBook:~/kubebapath/src/k8s.io/kubernetes/_output/bin$ ./e2e.test --provider=local --ginkgo.focus="validates that NodeSelector is respected if not matching" --kubeconfig=/home/root1/.kube/config 2>&1  | tee nodeselector_e2e_conformance.log
I0502 15:01:16.025605   32622 e2e.go:240] Starting e2e run "3a47bfbe-7bcd-45c3-a535-c8e6d847271c" on Ginkgo node 1
Running Suite: Kubernetes e2e suite
===================================
Random Seed: 1556789475 - Will randomize all specs
Will run 1 of 4082 specs

May  2 15:01:16.119: INFO: >>> kubeConfig: /home/root1/.kube/config
May  2 15:01:16.121: INFO: Waiting up to 30m0s for all (but 0) nodes to be schedulable
May  2 15:01:16.133: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
May  2 15:01:16.155: INFO: 13 / 13 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
May  2 15:01:16.155: INFO: expected 2 pod replicas in namespace 'kube-system', 2 are Running and Ready.
May  2 15:01:16.155: INFO: Waiting up to 5m0s for all daemonsets in namespace 'kube-system' to start
May  2 15:01:16.163: INFO: 4 / 4 pods ready in namespace 'kube-system' in daemonset 'kube-proxy' (0 seconds elapsed)
May  2 15:01:16.163: INFO: 4 / 4 pods ready in namespace 'kube-system' in daemonset 'weave-net' (0 seconds elapsed)
May  2 15:01:16.163: INFO: e2e test version: v1.15.0-alpha.1.303+8ec6167f61463c
May  2 15:01:16.163: INFO: kube-apiserver version: v1.13.4

------------------------------
[sig-scheduling] SchedulerPredicates [Serial] 
  validates that NodeSelector is respected if not matching  [Conformance]
  /home/root1/kubebapath/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:696
[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
  /home/root1/kubebapath/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:149
STEP: Creating a kubernetes client
May  2 15:01:16.181: INFO: >>> kubeConfig: /home/root1/.kube/config
STEP: Building a namespace api object, basename sched-pred
May  2 15:01:16.312: INFO: No PodSecurityPolicies found; assuming PodSecurityPolicy is disabled.
STEP: Waiting for a default service account to be provisioned in namespace
[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
  /home/root1/kubebapath/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
  /home/root1/kubebapath/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:150
May  2 15:01:17.355: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
STEP: Destroying namespace "sched-pred-5631" for this suite.
May  2 15:01:23.375: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
May  2 15:01:23.446: INFO: namespace sched-pred-5631 deletion completed in 6.088701478s
[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
  /home/root1/kubebapath/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70

• [SLOW TEST:7.265 seconds]
[sig-scheduling] SchedulerPredicates [Serial]
/home/root1/kubebapath/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
  validates that NodeSelector is respected if not matching  [Conformance]
  /home/root1/kubebapath/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:696
------------------------------
 2 15:01:23.452: INFO: Running AfterSuite actions on all nodes
May  2 15:01:23.452: INFO: Running AfterSuite actions on node 1

Ran 1 of 4082 Specs in 7.336 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 4081 Skipped
PASS

```

```
root1@root1-HP-EliteBook:~/kubebapath/src/k8s.io/kubernetes/_output/bin$ ./e2e.test --provider=local --ginkgo.focus="validates resource limits of pods that are allowed to run" --kubeconfig=/home/root1/.kube/config 2>&1  | tee resource_limit_e2e_conformance.log
I0502 15:01:30.971584     495 e2e.go:240] Starting e2e run "ebf653f4-784e-43e8-9cee-dbde89728fda" on Ginkgo node 1
Running Suite: Kubernetes e2e suite
===================================
Random Seed: 1556789490 - Will randomize all specs
Will run 1 of 4082 specs

May  2 15:01:31.064: INFO: >>> kubeConfig: /home/root1/.kube/config
May  2 15:01:31.066: INFO: Waiting up to 30m0s for all (but 0) nodes to be schedulable
May  2 15:01:31.077: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
May  2 15:01:31.099: INFO: 13 / 13 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
May  2 15:01:31.099: INFO: expected 2 pod replicas in namespace 'kube-system', 2 are Running and Ready.
May  2 15:01:31.099: INFO: Waiting up to 5m0s for all daemonsets in namespace 'kube-system' to start
May  2 15:01:31.107: INFO: 4 / 4 pods ready in namespace 'kube-system' in daemonset 'kube-proxy' (0 seconds elapsed)
May  2 15:01:31.107: INFO: 4 / 4 pods ready in namespace 'kube-system' in daemonset 'weave-net' (0 seconds elapsed)
May  2 15:01:31.107: INFO: e2e test version: v1.15.0-alpha.1.303+8ec6167f61463c
May  2 15:01:31.108: INFO: kube-apiserver version: v1.13.4
------------------------------
[sig-scheduling] SchedulerPredicates [Serial] 
  validates resource limits of pods that are allowed to run  [Conformance]
  /home/root1/kubebapath/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:696
[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
  /home/root1/kubebapath/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:149
STEP: Creating a kubernetes client
May  2 15:01:31.123: INFO: >>> kubeConfig: /home/root1/.kube/config
STEP: Building a namespace api object, basename sched-pred
May  2 15:01:31.201: INFO: No PodSecurityPolicies found; assuming PodSecurityPolicy is disabled.
STEP: Waiting for a default service account to be provisioned in namespace
[BeforeEach] [sig-scheduling] SchedulerPredicates [Serial]
  /home/root1/kubebapath/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:79
[AfterEach] [sig-scheduling] SchedulerPredicates [Serial]
  /home/root1/kubebapath/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/scheduling/predicates.go:70

• [SLOW TEST:15.510 seconds]
[sig-scheduling] SchedulerPredicates [Serial]
/home/root1/kubebapath/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/scheduling/framework.go:22
  validates resource limits of pods that are allowed to run  [Conformance]
  /home/root1/kubebapath/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:696
---------------------- 2 15:01:46.643: INFO: Running AfterSuite actions on all nodes
May  2 15:01:46.643: INFO: Running AfterSuite actions on node 1

Ran 1 of 4082 Specs in 15.582 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 4081 Skipped
PASS
root1@root1-HP-EliteBook:~/kubebapath/src/k8s.io/kubernetes/_output/bin$ 

```

Kube-batch E2E test results:
```
Ran 17 of 20 Specs in 744.379 seconds
SUCCESS! -- 17 Passed | 0 Failed | 0 Pending | 3 Skipped
--- PASS: TestE2E (744.38s)
PASS
ok  	github.com/kubernetes-sigs/kube-batch/test/e2e	744.388s
```