### PR TITLE
added reservation (starvation prevention)

### DIFF
--- a/doc/design/plugin-conf.md
+++ b/doc/design/plugin-conf.md
@@ -22,7 +22,14 @@ scenario on the fly.
 The following YAML format will be introduced for dynamic plugin configuration:
 
 ```yaml
-actions: "list_of_action_in_order"
+actions:
+- name: action_1
+  options:
+    key1: val1
+    key2: val2
+- name: action_2
+- name: action_3
+- name: action_4
 tiers:
 - plugins:
   - name: "plugin_1"
@@ -54,7 +61,11 @@ will preempt other jobs, although it's already allocated "enough" resource accor
 1. `"tiers.plugins.drf.disableTaskOrder"` is `true`, so `drf` will not impact task order phase/action
 
 ```yaml
-actions: "reclaim, allocate, backfill, preempt"
+actions:
+- name: reclaim
+- name: allocate
+- name: backfill
+- name: preempt
 tiers:
 - plugins:
   - name: "priority"

--- a/doc/design/reclaim-action.md
+++ b/doc/design/reclaim-action.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-In kube-batch there are 4 actions such as allocate, preempt, reclaim, backfill and with the help of plugins like conformance, drf, gang, nodeorder and more plugins. All these plugins provides behavioural characteristics how scheduler make scheduling decisions.
+In kube-batch there are 4 actions such as allocate, preempt, reclaim, reserve and with the help of plugins like conformance, drf, gang, nodeorder and more plugins. All these plugins provides behavioural characteristics how scheduler make scheduling decisions.
 
 ## Reclaim Action
 

--- a/doc/usage/tutorial.md
+++ b/doc/usage/tutorial.md
@@ -57,7 +57,9 @@ Please check following configurable fields and customize kube-batch based on you
 By default, scheduler will read following default configuraion as `scheduler-conf`.
 
 ```yaml
-actions: "allocate, backfill"
+actions:
+- name: allocate
+- name: backfill
 tiers:
 - plugins:
   - name: priority

--- a/example/kube-batch-conf.yaml
+++ b/example/kube-batch-conf.yaml
@@ -1,4 +1,12 @@
-actions: "reclaim, allocate, backfill, preempt"
+actions:
+- name: reserve
+  arguments:
+    enabled: true
+    threshold: 48h
+- name: reclaim
+- name: allocate
+- name: backfill
+- name: preempt
 tiers:
 - plugins:
   - name: priority

--- a/example/volcano/kube-batch-conf.yaml
+++ b/example/volcano/kube-batch-conf.yaml
@@ -1,12 +1,8 @@
 actions:
-- name: reserve
-  arguments:
-    enabled: true
-    threshold: 40s
 - name: reclaim
 - name: allocate
-- name: backfill
 - name: preempt
+- name: reserve
 tiers:
 - plugins:
   - name: priority

--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -4,7 +4,6 @@ pkg/apis/scheduling/v1alpha1
 pkg/apis/scheduling/v1alpha2
 pkg/apis/utils
 pkg/scheduler/actions/allocate
-pkg/scheduler/actions/backfill
 pkg/scheduler/actions/preempt
 pkg/scheduler/actions/reclaim
 test/e2e

--- a/pkg/apis/scheduling/v1alpha1/labels.go
+++ b/pkg/apis/scheduling/v1alpha1/labels.go
@@ -19,3 +19,6 @@ package v1alpha1
 // GroupNameAnnotationKey is the annotation key of Pod to identify
 // which PodGroup it belongs to.
 const GroupNameAnnotationKey = "scheduling.k8s.io/group-name"
+
+// DefaultStarvingThreshold time.Duration = 48 * time.Hour
+const DefaultStarvingThreshold string = "48h"

--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -27,11 +27,14 @@ import (
 )
 
 type allocateAction struct {
-	ssn *framework.Session
+	ssn       *framework.Session
+	arguments framework.Arguments
 }
 
-func New() *allocateAction {
-	return &allocateAction{}
+func New(args framework.Arguments) framework.Action {
+	return &allocateAction{
+		arguments: args,
+	}
 }
 
 func (alloc *allocateAction) Name() string {
@@ -152,7 +155,7 @@ func (alloc *allocateAction) Execute(ssn *framework.Session) {
 			if task.InitResreq.LessEqual(node.Idle) {
 				glog.V(3).Infof("Binding Task <%v/%v> to node <%v>",
 					task.Namespace, task.Name, node.Name)
-				if err := ssn.Allocate(task, node.Name); err != nil {
+				if err := ssn.Allocate(task, node); err != nil {
 					glog.Errorf("Failed to bind Task %v on %v in Session %v, err: %v",
 						task.UID, node.Name, ssn.UID, err)
 				}

--- a/pkg/scheduler/actions/allocate/allocate_test.go
+++ b/pkg/scheduler/actions/allocate/allocate_test.go
@@ -144,7 +144,8 @@ func TestAllocate(t *testing.T) {
 		},
 	}
 
-	allocate := New()
+	arguments := framework.Arguments{}
+	allocate := New(arguments)
 
 	for i, test := range tests {
 		binder := &util.FakeBinder{

--- a/pkg/scheduler/actions/backfill/backfill.go
+++ b/pkg/scheduler/actions/backfill/backfill.go
@@ -18,17 +18,20 @@ package backfill
 
 import (
 	"github.com/golang/glog"
-
 	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler/api"
 	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler/framework"
 )
 
 type backfillAction struct {
-	ssn *framework.Session
+	ssn       *framework.Session
+	arguments framework.Arguments
 }
 
-func New() *backfillAction {
-	return &backfillAction{}
+// New inits the action
+func New(args framework.Arguments) framework.Action {
+	return &backfillAction{
+		arguments: args,
+	}
 }
 
 func (alloc *backfillAction) Name() string {
@@ -57,7 +60,7 @@ func (alloc *backfillAction) Execute(ssn *framework.Session) {
 					}
 
 					glog.V(3).Infof("Binding Task <%v/%v> to node <%v>", task.Namespace, task.Name, node.Name)
-					if err := ssn.Allocate(task, node.Name); err != nil {
+					if err := ssn.Allocate(task, node); err != nil {
 						glog.Errorf("Failed to bind Task %v on %v in Session %v", task.UID, node.Name, ssn.UID)
 						continue
 					}

--- a/pkg/scheduler/actions/factory.go
+++ b/pkg/scheduler/actions/factory.go
@@ -17,6 +17,7 @@ limitations under the License.
 package actions
 
 import (
+	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler/actions/reserve"
 	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler/framework"
 
 	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler/actions/allocate"
@@ -26,8 +27,9 @@ import (
 )
 
 func init() {
-	framework.RegisterAction(reclaim.New())
-	framework.RegisterAction(allocate.New())
-	framework.RegisterAction(backfill.New())
-	framework.RegisterAction(preempt.New())
+	framework.RegisterAction("reclaim", reclaim.New)
+	framework.RegisterAction("allocate", allocate.New)
+	framework.RegisterAction("backfill", backfill.New)
+	framework.RegisterAction("reserve", reserve.New)
+	framework.RegisterAction("preempt", preempt.New)
 }

--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -28,11 +28,14 @@ import (
 )
 
 type preemptAction struct {
-	ssn *framework.Session
+	ssn       *framework.Session
+	arguments framework.Arguments
 }
 
-func New() *preemptAction {
-	return &preemptAction{}
+func New(args framework.Arguments) framework.Action {
+	return &preemptAction{
+		arguments: args,
+	}
 }
 
 func (alloc *preemptAction) Name() string {

--- a/pkg/scheduler/actions/preempt/preempt_test.go
+++ b/pkg/scheduler/actions/preempt/preempt_test.go
@@ -131,7 +131,8 @@ func TestPreempt(t *testing.T) {
 		},
 	}
 
-	allocate := New()
+	arguments := framework.Arguments{}
+	allocate := New(arguments)
 
 	for i, test := range tests {
 		binder := &util.FakeBinder{

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -25,11 +25,14 @@ import (
 )
 
 type reclaimAction struct {
-	ssn *framework.Session
+	ssn       *framework.Session
+	arguments framework.Arguments
 }
 
-func New() *reclaimAction {
-	return &reclaimAction{}
+func New(args framework.Arguments) framework.Action {
+	return &reclaimAction{
+		arguments: args,
+	}
 }
 
 func (alloc *reclaimAction) Name() string {

--- a/pkg/scheduler/actions/reclaim/reclaim_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_test.go
@@ -100,7 +100,8 @@ func TestReclaim(t *testing.T) {
 		},
 	}
 
-	reclaim := New()
+	arguments := framework.Arguments{}
+	reclaim := New(arguments)
 
 	for i, test := range tests {
 		binder := &util.FakeBinder{

--- a/pkg/scheduler/actions/reserve/reserve.go
+++ b/pkg/scheduler/actions/reserve/reserve.go
@@ -1,0 +1,249 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reserve
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/kubernetes-sigs/kube-batch/pkg/apis/scheduling/v1alpha1"
+
+	"github.com/golang/glog"
+	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler/api"
+	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler/framework"
+	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler/util"
+)
+
+type reserveAction struct {
+	ssn       *framework.Session
+	arguments framework.Arguments
+}
+
+// New inits an action
+func New(args framework.Arguments) framework.Action {
+	return &reserveAction{
+		arguments: args,
+	}
+}
+
+func (alloc *reserveAction) Name() string {
+	return "reserve"
+}
+
+func (alloc *reserveAction) Initialize() {}
+
+func (alloc *reserveAction) Execute(ssn *framework.Session) {
+	glog.V(3).Infof("Enter Reserve ...")
+	defer glog.V(3).Infof("Leaving Reserve ...")
+
+	enabled := false
+	alloc.arguments.GetBool(&enabled, "enabled")
+	if !enabled {
+		glog.V(3).Infof("Reserve disabled")
+		return
+	}
+
+	// get the starvation threshold time
+	var threshold time.Duration
+	err := alloc.getStarvationThreshold(&threshold)
+	if err != nil {
+		return
+	}
+
+	// collect starving jobs
+	queues := util.NewPriorityQueue(ssn.QueueOrderFn)
+	jobsMap := map[api.QueueID]*util.PriorityQueue{}
+
+	for _, job := range ssn.Jobs {
+		if queue, found := ssn.Queues[job.Queue]; found {
+			queues.Push(queue)
+		} else {
+			glog.V(4).Infof("Skip adding job <%s/%s> because its queue %s is not found",
+				job.Namespace, job.Name, job.Queue)
+			continue
+		}
+		if !isJobStarving(job, threshold) {
+			glog.V(4).Infof("Skip adding job <%s/%s> because it is not starving",
+				job.Namespace, job.Name, job.Queue)
+			continue
+		}
+
+		if _, found := jobsMap[job.Queue]; !found {
+			jobsMap[job.Queue] = util.NewPriorityQueue(ssn.JobOrderFn)
+		}
+
+		glog.V(4).Infof("Added Job <%s/%s> into Queue <%s>", job.Namespace, job.Name, job.Queue)
+		jobsMap[job.Queue].Push(job)
+	}
+
+	pendingTasks := map[api.JobID]*util.PriorityQueue{}
+	allNodes := util.GetNodeList(ssn.Nodes)
+	predicateFn := func(task *api.TaskInfo, node *api.NodeInfo) error {
+		// a node is elligible for starving job if its allocatable >= task.InitResreq
+		if !task.InitResreq.LessEqual(node.Allocatable) {
+			return fmt.Errorf("task <%s/%s> ResourceFit failed on node <%s>",
+				task.Namespace, task.Name, node.Name)
+		}
+		return ssn.PredicateFn(task, node)
+	}
+
+	// (over-)allocate resource to starving jobs
+	for {
+		if queues.Empty() {
+			break
+		}
+
+		queue := queues.Pop().(*api.QueueInfo)
+		if ssn.Overused(queue) {
+			glog.V(3).Infof("Queue <%s> is overused, ignore it.", queue.Name)
+			continue
+		}
+
+		jobs, found := jobsMap[queue.UID]
+		if !found || jobs.Empty() {
+			glog.V(4).Infof("Cannot find jobs for queue %s.", queue.Name)
+			continue
+		}
+
+		// collect all pending tasks of the starving job
+		job := jobs.Pop().(*api.JobInfo)
+		if _, found := pendingTasks[job.UID]; !found {
+			tasks := util.NewPriorityQueue(ssn.TaskOrderFn)
+			for _, task := range job.TaskStatusIndex[api.Pending] {
+				// Skip BestEffort task in 'allocate' action.
+				if task.Resreq.IsEmpty() {
+					glog.V(4).Infof("Task <%v/%v> is BestEffort task, skip it.",
+						task.Namespace, task.Name)
+					continue
+				}
+
+				tasks.Push(task)
+			}
+			pendingTasks[job.UID] = tasks
+		}
+		tasks := pendingTasks[job.UID]
+
+		glog.V(3).Infof("Trying to reserve resource for %d tasks of starving Job <%v/%v>",
+			tasks.Len(), job.Namespace, job.Name)
+
+		for !tasks.Empty() {
+			task := tasks.Pop().(*api.TaskInfo)
+
+			glog.V(3).Infof("There are <%d> nodes for Job <%v/%v>",
+				len(ssn.Nodes), job.Namespace, job.Name)
+
+			if len(job.NodesFitDelta) > 0 {
+				job.NodesFitDelta = make(api.NodeResourceMap)
+			}
+
+			// Going through all the nodes.
+			// When allocating for starving, node needs
+			// to be offered in consistent order
+			// If no node is available, task will not be allocated
+			// in any case
+			nodes := util.PredicateNodes(task, allNodes, predicateFn)
+			if len(nodes) == 0 {
+				break
+			}
+
+			taskAllocated := false
+			for _, node := range nodes {
+				// Allocate idle resource to the task.
+				if task.InitResreq.LessEqual(node.Idle) || toOverAllocate(ssn, node, threshold, task) {
+					if err := ssn.Allocate(task, node); err != nil {
+						glog.Errorf("Failed to bind task %v on %v in Session %v, err: %v",
+							task.UID, node.Name, ssn.UID, err)
+					}
+					taskAllocated = true
+					glog.V(3).Infof("Bond task <%v/%v> to node <%v>",
+						task.Namespace, task.Name, node.Name)
+					break
+				} else {
+					job.NodesFitDelta[node.Name] = node.Idle.Clone()
+					job.NodesFitDelta[node.Name].FitDelta(task.InitResreq)
+				}
+			}
+
+			// stop trying for this job if no (more) nodes available for this task
+			if !taskAllocated {
+				break
+			}
+
+			if ssn.JobReady(job) {
+				jobs.Push(job)
+				break
+			}
+		}
+
+		// Added Queue back until no job in Queue.
+		queues.Push(queue)
+	}
+}
+
+// ToOverAllocate check if it is okay to allocate resource on given node ignoring
+// running tasks
+func toOverAllocate(ssn *framework.Session, node *api.NodeInfo,
+	StarvationThreshold time.Duration, task *api.TaskInfo) bool {
+	job, found := ssn.Jobs[task.Job]
+	if !found {
+		return false
+	}
+	isJobStarving := isJobStarving(job, StarvationThreshold)
+	if !isJobStarving {
+		return false
+	}
+
+	// allow over-allocate for starving job
+	netResource := node.Allocatable.Clone()
+	for _, nodeTask := range node.Tasks {
+		if nodeTask.Status == api.Borrowing ||
+			nodeTask.Status == api.Allocated {
+			netResource.Sub(nodeTask.InitResreq)
+		}
+	}
+
+	// return true means when allocating for starving job, over-allocate resources ignoring
+	// resources being used on the node to prevent other non-startving job from taking the resources
+	return !task.InitResreq.LessEqual(node.Idle) &&
+		task.InitResreq.LessEqual(netResource)
+}
+
+func isJobStarving(jobInfo *api.JobInfo, starvationThreshold time.Duration) bool {
+	readiness := jobInfo.GetReadiness()
+	return readiness != api.Ready &&
+		readiness != api.ConditionallyReady &&
+		time.Since(jobInfo.CreationTimestamp.Time) >= starvationThreshold
+}
+
+func (alloc *reserveAction) getStarvationThreshold(threshold *time.Duration) error {
+	zeroDuration, _ := time.ParseDuration("0h")
+	*threshold = zeroDuration
+	alloc.arguments.GetTimeDuration(threshold, "threshold")
+	if *threshold == zeroDuration {
+		var err error
+		*threshold, err = time.ParseDuration(v1alpha1.DefaultStarvingThreshold)
+		if err != nil {
+			glog.Error("no valid default starvation setting: %v", v1alpha1.DefaultStarvingThreshold)
+			return err
+		}
+		glog.Infof("no starvation threshold time in config. using default value %v", threshold)
+	}
+
+	return nil
+}
+
+func (alloc *reserveAction) UnInitialize() {}

--- a/pkg/scheduler/api/resource_info.go
+++ b/pkg/scheduler/api/resource_info.go
@@ -141,22 +141,17 @@ func (r *Resource) Add(rr *Resource) *Resource {
 
 //Sub subtracts two Resource objects.
 func (r *Resource) Sub(rr *Resource) *Resource {
-	if rr.LessEqual(r) {
-		r.MilliCPU -= rr.MilliCPU
-		r.Memory -= rr.Memory
+	r.MilliCPU -= rr.MilliCPU
+	r.Memory -= rr.Memory
 
-		for rrName, rrQuant := range rr.ScalarResources {
-			if r.ScalarResources == nil {
-				return r
-			}
-			r.ScalarResources[rrName] -= rrQuant
+	for rrName, rrQuant := range rr.ScalarResources {
+		if r.ScalarResources == nil {
+			return r
 		}
-
-		return r
+		r.ScalarResources[rrName] -= rrQuant
 	}
 
-	panic(fmt.Errorf("Resource is not sufficient to do operation: <%v> sub <%v>",
-		r, rr))
+	return r
 }
 
 // SetMaxResource compares with ResourceList and takes max value for each Resource.

--- a/pkg/scheduler/api/test_utils.go
+++ b/pkg/scheduler/api/test_utils.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/kubernetes-sigs/kube-batch/pkg/apis/scheduling/v1alpha1"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -72,6 +74,7 @@ func buildPod(ns, n, nn string, p v1.PodPhase, req v1.ResourceList, owner []meta
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:             types.UID(fmt.Sprintf("%v-%v", ns, n)),
+			Annotations:     map[string]string{v1alpha1.GroupNameAnnotationKey: "testpodgroup"},
 			Name:            n,
 			Namespace:       ns,
 			OwnerReferences: owner,

--- a/pkg/scheduler/api/types.go
+++ b/pkg/scheduler/api/types.go
@@ -23,6 +23,12 @@ const (
 	// Pending means the task is pending in the apiserver.
 	Pending TaskStatus = 1 << iota
 
+	// Borrowing means that the task is allocated borrowing resources
+	// that are currently occupied by tasks.
+	// Task T is allocated to Node N as an Borrowing task if,
+	// and only if, N.IdleResource < T.RequestResource <= N.AllocatableResource.
+	Borrowing
+
 	// Allocated means the scheduler assigns a host to it.
 	Allocated
 
@@ -53,10 +59,40 @@ const (
 	Unknown
 )
 
+// JobReadiness type of job readiness
+type JobReadiness int
+
+const (
+	// Ready : a job is Ready if the number of tasks in Allocated state
+	// exceeds the job's minimum task number requirement. In other words,
+	// #(Allocated Tasks) >= Job.MinAvailable
+	// A Ready job can be dispatch to a node right away.
+	Ready JobReadiness = 1 << iota
+
+	// ConditionallyReady : a job is ConditionallyReady if the job is not Ready for dispatch, but
+	// the number of tasks in Allocated state exceeds the job's minim task
+	// number requirement. In other words,
+	// #(Allocated Tasks) < Job.MinAvailable &&
+	// #(Allocated Tasks) + #(AllocatedOverBackFill Tasks) >= Job.MinAvailable
+	ConditionallyReady
+
+	// NotReady : #(Allocated Tasks) + #(AllocatedOverBackFill Tasks) < Job.MinAvailable
+	NotReady
+)
+
+// AllocatedStatuses all status of allocated
+func AllocatedStatuses() []TaskStatus {
+	return []TaskStatus{Bound, Binding, Running, Allocated}
+}
+
 func (ts TaskStatus) String() string {
 	switch ts {
 	case Pending:
 		return "Pending"
+	case Allocated:
+		return "Allocated"
+	case Borrowing:
+		return "Borrowing"
 	case Binding:
 		return "Binding"
 	case Bound:

--- a/pkg/scheduler/cache/interface.go
+++ b/pkg/scheduler/cache/interface.go
@@ -66,7 +66,7 @@ type Binder interface {
 	Bind(task *v1.Pod, hostname string) error
 }
 
-// Evictor interface for evict pods
+// Evictor interface for evicting pods
 type Evictor interface {
 	Evict(pod *v1.Pod) error
 }

--- a/pkg/scheduler/cache/util.go
+++ b/pkg/scheduler/cache/util.go
@@ -47,8 +47,9 @@ func createShadowPodGroup(pod *v1.Pod) *v1alpha1.PodGroup {
 
 	return &v1alpha1.PodGroup{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: pod.Namespace,
-			Name:      string(jobID),
+			Namespace:         pod.Namespace,
+			Name:              string(jobID),
+			CreationTimestamp: pod.CreationTimestamp,
 			Annotations: map[string]string{
 				shadowPodGroupKey: string(jobID),
 			},

--- a/pkg/scheduler/conf/scheduler_conf.go
+++ b/pkg/scheduler/conf/scheduler_conf.go
@@ -16,17 +16,30 @@ limitations under the License.
 
 package conf
 
+import "time"
+
 // SchedulerConfiguration defines the configuration of scheduler.
 type SchedulerConfiguration struct {
 	// Actions defines the actions list of scheduler in order
-	Actions string `yaml:"actions"`
+	Actions []SchedulerAction `yaml:"actions"`
 	// Tiers defines plugins in different tiers
 	Tiers []Tier `yaml:"tiers"`
 }
 
+const (
+	// DefaultStarvingThreshold sets the default value for Starvation Threshold
+	DefaultStarvingThreshold time.Duration = 48 * time.Hour
+)
+
 // Tier defines plugin tier
 type Tier struct {
 	Plugins []PluginOption `yaml:"plugins"`
+}
+
+// SchedulerAction defines action with its options
+type SchedulerAction struct {
+	Name      string            `yaml:"name"`
+	Arguments map[string]string `yaml:"arguments"`
 }
 
 // PluginOption defines the options of plugin
@@ -51,6 +64,9 @@ type PluginOption struct {
 	EnabledPredicate *bool `yaml:"enablePredicate"`
 	// EnabledNodeOrder defines whether NodeOrderFn is enabled
 	EnabledNodeOrder *bool `yaml:"enableNodeOrder"`
+	// Starvation Threshold. Jobs that have been pending longer than
+	// the threshold are considered as starving jobs.
+	StarvationThreshold time.Duration `yaml:"starvation-threshold"`
 	// Arguments defines the different arguments that can be given to different plugins
 	Arguments map[string]string `yaml:"arguments"`
 }

--- a/pkg/scheduler/framework/arguments.go
+++ b/pkg/scheduler/framework/arguments.go
@@ -18,6 +18,7 @@ package framework
 
 import (
 	"strconv"
+	"time"
 
 	"github.com/golang/glog"
 )
@@ -26,17 +27,57 @@ import (
 type Arguments map[string]string
 
 //GetInt get the integer value from string
-func (a Arguments) GetInt(ptr *int, key string) {
+func (arg Arguments) GetInt(ptr *int, key string) {
 	if ptr == nil {
 		return
 	}
 
-	argv, ok := a[key]
+	argv, ok := arg[key]
 	if !ok || argv == "" {
 		return
 	}
 
 	value, err := strconv.Atoi(argv)
+	if err != nil {
+		glog.Warningf("Could not parse argument: %s for key %s, with err %v", argv, key, err)
+		return
+	}
+
+	*ptr = value
+}
+
+//GetBool get the integer value from string
+func (arg Arguments) GetBool(ptr *bool, key string) {
+	if ptr == nil {
+		return
+	}
+
+	argv, ok := arg[key]
+	if !ok || argv == "" {
+		return
+	}
+
+	value, err := strconv.ParseBool(argv)
+	if err != nil {
+		glog.Warningf("Could not parse argument: %s for key %s, with err %v", argv, key, err)
+		return
+	}
+
+	*ptr = value
+}
+
+//GetTimeDuration gets the time duration value from string
+func (arg Arguments) GetTimeDuration(ptr *time.Duration, key string) {
+	if ptr == nil {
+		return
+	}
+
+	argv, ok := arg[key]
+	if !ok || argv == "" {
+		return
+	}
+
+	value, err := time.ParseDuration(argv)
 	if err != nil {
 		glog.Warningf("Could not parse argument: %s for key %s, with err %v", argv, key, err)
 		return

--- a/pkg/scheduler/framework/arguments_test.go
+++ b/pkg/scheduler/framework/arguments_test.go
@@ -18,6 +18,7 @@ package framework
 
 import (
 	"testing"
+	"time"
 )
 
 type GetIntTestCases struct {
@@ -25,6 +26,20 @@ type GetIntTestCases struct {
 	key         string
 	baseValue   int
 	expectValue int
+}
+
+type GetBooleanTestCases struct {
+	arg         Arguments
+	key         string
+	baseValue   bool
+	expectValue bool
+}
+
+type GetDurationTestCases struct {
+	arg         Arguments
+	key         string
+	baseValue   time.Duration
+	expectValue time.Duration
 }
 
 func TestArgumentsGetInt(t *testing.T) {
@@ -69,6 +84,136 @@ func TestArgumentsGetInt(t *testing.T) {
 		baseValue := c.baseValue
 		c.arg.GetInt(nil, c.key)
 		c.arg.GetInt(&baseValue, c.key)
+		if baseValue != c.expectValue {
+			t.Errorf("index %d, value should be %v, but not %v", index, c.expectValue, baseValue)
+		}
+	}
+}
+
+func TestArgumentsGetBoolean(t *testing.T) {
+	key := "key"
+
+	cases := []GetBooleanTestCases{
+		{
+			arg: Arguments{
+				"anotherkey": "false",
+			},
+			key:         key,
+			baseValue:   false,
+			expectValue: false,
+		},
+		{
+			arg: Arguments{
+				"anotherkey": "false",
+			},
+			key:         key,
+			baseValue:   true,
+			expectValue: true,
+		},
+		{
+			arg: Arguments{
+				key: "false",
+			},
+			key:         key,
+			baseValue:   false,
+			expectValue: false,
+		},
+		{
+			arg: Arguments{
+				key: "true",
+			},
+			key:         key,
+			baseValue:   false,
+			expectValue: true,
+		},
+		{
+			arg: Arguments{
+				key: "errorvalue",
+			},
+			key:         key,
+			baseValue:   false,
+			expectValue: false,
+		},
+		{
+			arg: Arguments{
+				key: "errorvalue",
+			},
+			key:         key,
+			baseValue:   true,
+			expectValue: true,
+		},
+		{
+			arg: Arguments{
+				key: "",
+			},
+			key:         key,
+			baseValue:   false,
+			expectValue: false,
+		},
+	}
+
+	for index, c := range cases {
+		baseValue := c.baseValue
+		c.arg.GetBool(nil, c.key)
+		c.arg.GetBool(&baseValue, c.key)
+		if baseValue != c.expectValue {
+			t.Errorf("index %d, value should be %v, but not %v", index, c.expectValue, baseValue)
+		}
+	}
+}
+
+func TestArgumentsGetDuration(t *testing.T) {
+	key := "key"
+	d2, _ := time.ParseDuration("2h")
+	d48, _ := time.ParseDuration("48h")
+
+	cases := []GetDurationTestCases{
+		{
+			arg: Arguments{
+				"anotherkey": "2h",
+			},
+			key:         key,
+			baseValue:   d48,
+			expectValue: d48,
+		},
+		{
+			arg: Arguments{
+				key: "2h",
+			},
+			key:         key,
+			baseValue:   d48,
+			expectValue: d2,
+		},
+		{
+			arg: Arguments{
+				key: "48h",
+			},
+			key:         key,
+			baseValue:   d48,
+			expectValue: d48,
+		},
+		{
+			arg: Arguments{
+				key: "errorvalue",
+			},
+			key:         key,
+			baseValue:   d2,
+			expectValue: d2,
+		},
+		{
+			arg: Arguments{
+				key: "",
+			},
+			key:         key,
+			baseValue:   d2,
+			expectValue: d2,
+		},
+	}
+
+	for index, c := range cases {
+		baseValue := c.baseValue
+		c.arg.GetTimeDuration(nil, c.key)
+		c.arg.GetTimeDuration(&baseValue, c.key)
 		if baseValue != c.expectValue {
 			t.Errorf("index %d, value should be %v, but not %v", index, c.expectValue, baseValue)
 		}

--- a/pkg/scheduler/framework/plugins.go
+++ b/pkg/scheduler/framework/plugins.go
@@ -52,18 +52,21 @@ func GetPluginBuilder(name string) (PluginBuilder, bool) {
 }
 
 // Action management
-var actionMap = map[string]Action{}
+var actionMap = map[string]ActionBuilder{}
+
+// ActionBuilder action management
+type ActionBuilder func(Arguments) Action
 
 // RegisterAction register action
-func RegisterAction(act Action) {
+func RegisterAction(name string, builder ActionBuilder) {
 	pluginMutex.Lock()
 	defer pluginMutex.Unlock()
 
-	actionMap[act.Name()] = act
+	actionMap[name] = builder
 }
 
 // GetAction get the action by name
-func GetAction(name string) (Action, bool) {
+func GetAction(name string) (ActionBuilder, bool) {
 	pluginMutex.Lock()
 	defer pluginMutex.Unlock()
 

--- a/pkg/scheduler/plugins/gang/gang.go
+++ b/pkg/scheduler/plugins/gang/gang.go
@@ -123,6 +123,7 @@ func (gp *gangPlugin) OnSessionOpen(ssn *framework.Session) {
 		ji := obj.(*api.JobInfo)
 		return ji.Ready()
 	})
+
 	ssn.AddJobPipelinedFn(gp.Name(), func(obj interface{}) bool {
 		ji := obj.(*api.JobInfo)
 		return ji.Pipelined()

--- a/pkg/scheduler/plugins/nodeorder/nodeorder.go
+++ b/pkg/scheduler/plugins/nodeorder/nodeorder.go
@@ -111,7 +111,11 @@ func calculateWeight(args framework.Arguments) priorityWeight {
 	   User Should give priorityWeight in this format(nodeaffinity.weight, podaffinity.weight, leastrequested.weight, balancedresource.weight).
 	   Currently supported only for nodeaffinity, podaffinity, leastrequested, balancedresouce priorities.
 
-	   actions: "reclaim, allocate, backfill, preempt"
+	   actions:
+	   - name: reclaim
+	   - name: allocate
+	   - name: backfill
+	   - name: preempt
 	   tiers:
 	   - plugins:
 	     - name: priority

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -77,11 +77,17 @@ func (pc *Scheduler) Run(stopCh <-chan struct{}) {
 		}
 	}
 
-	pc.actions, pc.plugins, err = loadSchedulerConf(schedConf)
-	if err != nil {
+	var config *conf.SchedulerConfiguration
+	if config, err = loadSchedulerConf(schedConf); err == nil {
+		pc.plugins = config.Tiers
+		pc.actions, err = getActions(config)
+	} else {
+		glog.Errorf("Failed to read scheduler configuration '%s': %s",
+			schedConf, err)
 		panic(err)
 	}
 
+	glog.V(4).Infof("pc setting %+v", pc)
 	go wait.Until(pc.runOnce, pc.schedulePeriod, stopCh)
 }
 

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1026,3 +1026,10 @@ func deleteReplicationController(ctx *context, name string) error {
 		PropagationPolicy: &foreground,
 	})
 }
+
+func deleteJob(ctx *context, name string) error {
+	foreground := metav1.DeletePropagationForeground
+	return ctx.kubeclient.BatchV1().Jobs(ctx.namespace).Delete(name, &metav1.DeleteOptions{
+		PropagationPolicy: &foreground,
+	})
+}


### PR DESCRIPTION
Added reservation (starvation prevention). 

Job that have exceeded the starvation threshold (configurable) will be allocated to node in a more forceful manner. The running jobs on a node will be ignored during allocation. This allows starving jobs to be "reserved" on these nodes. Once the running tasks exit, the starving jobs will be scheduled ahead of non-starving jobs.

