### PR TITLE
Fix wrong calculation for nodeinfo used

### DIFF
--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -90,6 +90,7 @@ func (ni *NodeInfo) SetNode(node *v1.Node) {
 	ni.Allocatable = NewResource(node.Status.Allocatable)
 	ni.Capability = NewResource(node.Status.Capacity)
 	ni.Idle = NewResource(node.Status.Allocatable)
+	ni.Used = EmptyResource()
 
 	for _, task := range ni.Tasks {
 		if task.Status == Releasing {


### PR DESCRIPTION
when node info is updated and set node, we should reset the `Used` to EmptyResource otherwise the Used is calculated twice when update node

/assign @k82cn @hex108 