### PR TITLE
Support Both versions of PodGroup

### DIFF
--- a/deployment/kube-batch/templates/scheduling_v1alpha2_podgroup.yaml
+++ b/deployment/kube-batch/templates/scheduling_v1alpha2_podgroup.yaml
@@ -1,0 +1,43 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: podgroups.scheduling.sigs.dev
+spec:
+  group: scheduling.sigs.dev
+  names:
+    kind: PodGroup
+    plural: podgroups
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            minMember:
+              format: int32
+              type: integer
+            queue:
+              type: string
+            priorityClassName:
+              type: string
+          type: object
+        status:
+          properties:
+            succeeded:
+              format: int32
+              type: integer
+            failed:
+              format: int32
+              type: integer
+            running:
+              format: int32
+              type: integer
+          type: object
+      type: object
+  version: v1alpha2

--- a/hack/run-e2e-kind.sh
+++ b/hack/run-e2e-kind.sh
@@ -71,6 +71,7 @@ function kube-batch-up {
 
     kubectl create -f deployment/kube-batch/templates/scheduling_v1alpha1_queue.yaml
     kubectl create -f deployment/kube-batch/templates/scheduling_v1alpha1_podgroup.yaml
+    kubectl create -f deployment/kube-batch/templates/scheduling_v1alpha2_podgroup.yaml
     kubectl create -f deployment/kube-batch/templates/default.yaml
 
     # start kube-batch

--- a/pkg/scheduler/actions/allocate/allocate_test.go
+++ b/pkg/scheduler/actions/allocate/allocate_test.go
@@ -169,7 +169,7 @@ func TestAllocate(t *testing.T) {
 		}
 
 		for _, ss := range test.podGroups {
-			schedulerCache.AddPodGroup(ss)
+			schedulerCache.AddPodGroupAlpha1(ss)
 		}
 
 		for _, q := range test.queues {

--- a/pkg/scheduler/actions/preempt/preempt_test.go
+++ b/pkg/scheduler/actions/preempt/preempt_test.go
@@ -161,7 +161,7 @@ func TestPreempt(t *testing.T) {
 		}
 
 		for _, ss := range test.podGroups {
-			schedulerCache.AddPodGroup(ss)
+			schedulerCache.AddPodGroupAlpha1(ss)
 		}
 
 		for _, q := range test.queues {

--- a/pkg/scheduler/actions/reclaim/reclaim_test.go
+++ b/pkg/scheduler/actions/reclaim/reclaim_test.go
@@ -130,7 +130,7 @@ func TestReclaim(t *testing.T) {
 		}
 
 		for _, ss := range test.podGroups {
-			schedulerCache.AddPodGroup(ss)
+			schedulerCache.AddPodGroupAlpha1(ss)
 		}
 
 		for _, q := range test.queues {

--- a/pkg/scheduler/api/job_info.go
+++ b/pkg/scheduler/api/job_info.go
@@ -147,7 +147,7 @@ type JobInfo struct {
 	TotalRequest *Resource
 
 	CreationTimestamp metav1.Time
-	PodGroup          *v1alpha1.PodGroup
+	PodGroup          *PodGroup
 
 	// TODO(k82cn): keep backward compatibility, removed it when v1alpha1 finalized.
 	PDB *policyv1.PodDisruptionBudget
@@ -181,7 +181,7 @@ func (ji *JobInfo) UnsetPodGroup() {
 }
 
 // SetPodGroup sets podGroup details to a job
-func (ji *JobInfo) SetPodGroup(pg *v1alpha1.PodGroup) {
+func (ji *JobInfo) SetPodGroup(pg *PodGroup) {
 	ji.Name = pg.Name
 	ji.Namespace = pg.Namespace
 	ji.MinAvailable = pg.Spec.MinMember

--- a/pkg/scheduler/api/pod_group_info.go
+++ b/pkg/scheduler/api/pod_group_info.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"encoding/json"
+
+	"github.com/golang/glog"
+	"github.com/kubernetes-sigs/kube-batch/pkg/apis/scheduling/v1alpha1"
+	"github.com/kubernetes-sigs/kube-batch/pkg/apis/scheduling/v1alpha2"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+//PodGroupConditionType is of string type which represents podGroup Condition
+type PodGroupConditionType string
+
+const (
+	//PodGroupUnschedulableType represents unschedulable podGroup condition
+	PodGroupUnschedulableType PodGroupConditionType = "Unschedulable"
+)
+
+// PodGroupPhase is the phase of a pod group at the current time.
+type PodGroupPhase string
+
+// These are the valid phase of podGroups.
+const (
+	//PodGroupVersionV1Alpha1 represents PodGroupVersion of V1Alpha1
+	PodGroupVersionV1Alpha1 string = "v1alpha1"
+
+	//PodGroupVersionV1Alpha2 represents PodGroupVersion of V1Alpha2
+	PodGroupVersionV1Alpha2 string = "v1alpha2"
+	// PodPending means the pod group has been accepted by the system, but scheduler can not allocate
+	// enough resources to it.
+	PodGroupPending PodGroupPhase = "Pending"
+
+	// PodRunning means `spec.minMember` pods of PodGroups has been in running phase.
+	PodGroupRunning PodGroupPhase = "Running"
+
+	// PodGroupUnknown means part of `spec.minMember` pods are running but the other part can not
+	// be scheduled, e.g. not enough resource; scheduler will wait for related controller to recover it.
+	PodGroupUnknown PodGroupPhase = "Unknown"
+)
+
+// PodGroupCondition contains details for the current state of this pod group.
+type PodGroupCondition struct {
+	// Type is the type of the condition
+	Type PodGroupConditionType `json:"type,omitempty" protobuf:"bytes,1,opt,name=type"`
+
+	// Status is the status of the condition.
+	Status v1.ConditionStatus `json:"status,omitempty" protobuf:"bytes,2,opt,name=status"`
+
+	// The ID of condition transition.
+	TransitionID string `json:"transitionID,omitempty" protobuf:"bytes,3,opt,name=transitionID"`
+
+	// Last time the phase transitioned from another to current phase.
+	// +optional
+	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty" protobuf:"bytes,4,opt,name=lastTransitionTime"`
+
+	// Unique, one-word, CamelCase reason for the phase's last transition.
+	// +optional
+	Reason string `json:"reason,omitempty" protobuf:"bytes,5,opt,name=reason"`
+
+	// Human-readable message indicating details about last transition.
+	// +optional
+	Message string `json:"message,omitempty" protobuf:"bytes,6,opt,name=message"`
+}
+
+// PodGroup is a collection of Pod; used for batch workload.
+type PodGroup struct {
+	metav1.TypeMeta `json:",inline"`
+	// Standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+	// +optional
+	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+	// Specification of the desired behavior of the pod group.
+	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status
+	// +optional
+	Spec PodGroupSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
+
+	// Status represents the current information about a pod group.
+	// This data may not be up to date.
+	// +optional
+	Status PodGroupStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
+
+	//Version represents the version of PodGroup
+	Version string
+}
+
+// PodGroupSpec represents the template of a pod group.
+type PodGroupSpec struct {
+	// MinMember defines the minimal number of members/tasks to run the pod group;
+	// if there's not enough resources to start all tasks, the scheduler
+	// will not start anyone.
+	MinMember int32 `json:"minMember,omitempty" protobuf:"bytes,1,opt,name=minMember"`
+
+	// Queue defines the queue to allocate resource for PodGroup; if queue does not exist,
+	// the PodGroup will not be scheduled.
+	Queue string `json:"queue,omitempty" protobuf:"bytes,2,opt,name=queue"`
+
+	// If specified, indicates the PodGroup's priority. "system-node-critical" and
+	// "system-cluster-critical" are two special keywords which indicate the
+	// highest priorities with the former being the highest priority. Any other
+	// name must be defined by creating a PriorityClass object with that name.
+	// If not specified, the PodGroup priority will be default or zero if there is no
+	// default.
+	// +optional
+	PriorityClassName string `json:"priorityClassName,omitempty" protobuf:"bytes,3,opt,name=priorityClassName"`
+}
+
+// PodGroupStatus represents the current state of a pod group.
+type PodGroupStatus struct {
+	// Current phase of PodGroup.
+	Phase PodGroupPhase `json:"phase,omitempty" protobuf:"bytes,1,opt,name=phase"`
+
+	// The conditions of PodGroup.
+	// +optional
+	Conditions []PodGroupCondition `json:"conditions,omitempty" protobuf:"bytes,2,opt,name=conditions"`
+
+	// The number of actively running pods.
+	// +optional
+	Running int32 `json:"running,omitempty" protobuf:"bytes,3,opt,name=running"`
+
+	// The number of pods which reached phase Succeeded.
+	// +optional
+	Succeeded int32 `json:"succeeded,omitempty" protobuf:"bytes,4,opt,name=succeeded"`
+
+	// The number of pods which reached phase Failed.
+	// +optional
+	Failed int32 `json:"failed,omitempty" protobuf:"bytes,5,opt,name=failed"`
+}
+
+//ConvertPodGroupInfoToV1Alpha converts api.PodGroup type to v1alpha1.PodGroup
+func ConvertPodGroupInfoToV1Alpha(pg *PodGroup) (*v1alpha1.PodGroup, error) {
+	marshalled, err := json.Marshal(*pg)
+	if err != nil {
+		glog.Errorf("Failed to Marshal podgroup %s with error: %v", pg.Name, err)
+	}
+
+	convertedPg := &v1alpha1.PodGroup{}
+	err = json.Unmarshal(marshalled, convertedPg)
+	if err != nil {
+		glog.Errorf("Failed to Unmarshal Data into v1alpha1.PodGroup type with error: %v", err)
+	}
+
+	return convertedPg, nil
+}
+
+//ConvertV1Alpha1ToPodGroupInfo converts v1alpha1.PodGroup to api.PodGroup type
+func ConvertV1Alpha1ToPodGroupInfo(pg *v1alpha1.PodGroup) (*PodGroup, error) {
+	marshalled, err := json.Marshal(*pg)
+	if err != nil {
+		glog.Errorf("Failed to Marshal podgroup %s with error: %v", pg.Name, err)
+	}
+
+	convertedPg := &PodGroup{}
+	err = json.Unmarshal(marshalled, convertedPg)
+	if err != nil {
+		glog.Errorf("Failed to Unmarshal Data into api.PodGroup type with error: %v", err)
+	}
+	convertedPg.Version = PodGroupVersionV1Alpha1
+
+	return convertedPg, nil
+}
+
+//ConvertPodGroupInfoToV2Alpha converts api.PodGroup type to v1alpha2.PodGroup
+func ConvertPodGroupInfoToV2Alpha(pg *PodGroup) (*v1alpha2.PodGroup, error) {
+	marshalled, err := json.Marshal(*pg)
+	if err != nil {
+		glog.Errorf("Failed to Marshal podgroup %s with error: %v", pg.Name, err)
+	}
+
+	convertedPg := &v1alpha2.PodGroup{}
+	err = json.Unmarshal(marshalled, convertedPg)
+	if err != nil {
+		glog.Errorf("Failed to Unmarshal Data into v1alpha2.PodGroup type with error: %v", err)
+	}
+
+	return convertedPg, nil
+}
+
+//ConvertV1Alpha2ToPodGroupInfo converts v1alpha2.PodGroup to api.PodGroup type
+func ConvertV1Alpha2ToPodGroupInfo(pg *v1alpha2.PodGroup) (*PodGroup, error) {
+	marshalled, err := json.Marshal(*pg)
+	if err != nil {
+		glog.Errorf("Failed to Marshal podgroup %s with error: %v", pg.Name, err)
+	}
+
+	convertedPg := &PodGroup{}
+	err = json.Unmarshal(marshalled, convertedPg)
+	if err != nil {
+		glog.Errorf("Failed to Unmarshal Data into api.PodGroup type with error: %v", err)
+	}
+	convertedPg.Version = PodGroupVersionV1Alpha2
+
+	return convertedPg, nil
+}

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -51,6 +51,7 @@ import (
 	kbschema "github.com/kubernetes-sigs/kube-batch/pkg/client/clientset/versioned/scheme"
 	kbinfo "github.com/kubernetes-sigs/kube-batch/pkg/client/informers/externalversions"
 	kbinfov1 "github.com/kubernetes-sigs/kube-batch/pkg/client/informers/externalversions/scheduling/v1alpha1"
+	kbinfov2 "github.com/kubernetes-sigs/kube-batch/pkg/client/informers/externalversions/scheduling/v1alpha2"
 	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler/api"
 	kbapi "github.com/kubernetes-sigs/kube-batch/pkg/scheduler/api"
 )
@@ -79,16 +80,17 @@ type SchedulerCache struct {
 	// schedulerName is the name for kube batch scheduler
 	schedulerName string
 
-	podInformer      infov1.PodInformer
-	nodeInformer     infov1.NodeInformer
-	pdbInformer      policyv1.PodDisruptionBudgetInformer
-	nsInformer       infov1.NamespaceInformer
-	podGroupInformer kbinfov1.PodGroupInformer
-	queueInformer    kbinfov1.QueueInformer
-	pvInformer       infov1.PersistentVolumeInformer
-	pvcInformer      infov1.PersistentVolumeClaimInformer
-	scInformer       storagev1.StorageClassInformer
-	pcInformer       schedv1.PriorityClassInformer
+	podInformer              infov1.PodInformer
+	nodeInformer             infov1.NodeInformer
+	pdbInformer              policyv1.PodDisruptionBudgetInformer
+	nsInformer               infov1.NamespaceInformer
+	podGroupInformerv1alpha1 kbinfov1.PodGroupInformer
+	podGroupInformerv1alpha2 kbinfov2.PodGroupInformer
+	queueInformer            kbinfov1.QueueInformer
+	pvInformer               infov1.PersistentVolumeInformer
+	pvcInformer              infov1.PersistentVolumeClaimInformer
+	scInformer               storagev1.StorageClassInformer
+	pcInformer               schedv1.PriorityClassInformer
 
 	Binder        Binder
 	Evictor       Evictor
@@ -158,8 +160,41 @@ func (su *defaultStatusUpdater) UpdatePodCondition(pod *v1.Pod, condition *v1.Po
 }
 
 // UpdatePodGroup will Update pod with podCondition
-func (su *defaultStatusUpdater) UpdatePodGroup(pg *v1alpha1.PodGroup) (*v1alpha1.PodGroup, error) {
-	return su.kbclient.SchedulingV1alpha1().PodGroups(pg.Namespace).Update(pg)
+func (su *defaultStatusUpdater) UpdatePodGroup(pg *api.PodGroup) (*api.PodGroup, error) {
+	if pg.Version == api.PodGroupVersionV1Alpha1 {
+		podGroup, err := api.ConvertPodGroupInfoToV1Alpha(pg)
+		if err != nil {
+			glog.Errorf("Error while converting PodGroup to v1alpha1.PodGroup with error: %v", err)
+		}
+		updated, err := su.kbclient.SchedulingV1alpha1().PodGroups(podGroup.Namespace).Update(podGroup)
+		if err != nil {
+			glog.Errorf("Error while updating podgroup with error: %v", err)
+		}
+		podGroupInfo, err := api.ConvertV1Alpha1ToPodGroupInfo(updated)
+		if err != nil {
+			glog.Errorf("Error While converting v1alpha.Podgroup to api.PodGroup with error: %v", err)
+			return nil, err
+		}
+		return podGroupInfo, nil
+	}
+
+	if pg.Version == api.PodGroupVersionV1Alpha2 {
+		podGroup, err := api.ConvertPodGroupInfoToV2Alpha(pg)
+		if err != nil {
+			glog.Errorf("Error while converting PodGroup to v1alpha2.PodGroup with error: %v", err)
+		}
+		updated, err := su.kbclient.SchedulingV1alpha2().PodGroups(podGroup.Namespace).Update(podGroup)
+		if err != nil {
+			glog.Errorf("Error while updating podgroup with error: %v", err)
+		}
+		podGroupInfo, err := api.ConvertV1Alpha2ToPodGroupInfo(updated)
+		if err != nil {
+			glog.Errorf("Error While converting v2alpha.Podgroup to api.PodGroup with error: %v", err)
+			return nil, err
+		}
+		return podGroupInfo, nil
+	}
+	return nil, fmt.Errorf("Provide Proper version of PodGroup, Invalid PodGroup version: %s", pg.Version)
 }
 
 type defaultVolumeBinder struct {
@@ -280,12 +315,20 @@ func newSchedulerCache(config *rest.Config, schedulerName string, defaultQueue s
 	})
 
 	kbinformer := kbinfo.NewSharedInformerFactory(sc.kbclient, 0)
-	// create informer for PodGroup information
-	sc.podGroupInformer = kbinformer.Scheduling().V1alpha1().PodGroups()
-	sc.podGroupInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    sc.AddPodGroup,
-		UpdateFunc: sc.UpdatePodGroup,
-		DeleteFunc: sc.DeletePodGroup,
+	// create informer for PodGroup(v1alpha1) information
+	sc.podGroupInformerv1alpha1 = kbinformer.Scheduling().V1alpha1().PodGroups()
+	sc.podGroupInformerv1alpha1.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    sc.AddPodGroupAlpha1,
+		UpdateFunc: sc.UpdatePodGroupAlpha1,
+		DeleteFunc: sc.DeletePodGroupAlpha1,
+	})
+
+	// create informer for PodGroup(v1alpha2) information
+	sc.podGroupInformerv1alpha2 = kbinformer.Scheduling().V1alpha2().PodGroups()
+	sc.podGroupInformerv1alpha2.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    sc.AddPodGroupAlpha2,
+		UpdateFunc: sc.UpdatePodGroupAlpha2,
+		DeleteFunc: sc.DeletePodGroupAlpha2,
 	})
 
 	// create informer for Queue information
@@ -304,7 +347,8 @@ func (sc *SchedulerCache) Run(stopCh <-chan struct{}) {
 	go sc.pdbInformer.Informer().Run(stopCh)
 	go sc.podInformer.Informer().Run(stopCh)
 	go sc.nodeInformer.Informer().Run(stopCh)
-	go sc.podGroupInformer.Informer().Run(stopCh)
+	go sc.podGroupInformerv1alpha1.Informer().Run(stopCh)
+	go sc.podGroupInformerv1alpha2.Informer().Run(stopCh)
 	go sc.pvInformer.Informer().Run(stopCh)
 	go sc.pvcInformer.Informer().Run(stopCh)
 	go sc.scInformer.Informer().Run(stopCh)
@@ -329,7 +373,8 @@ func (sc *SchedulerCache) WaitForCacheSync(stopCh <-chan struct{}) bool {
 			informerSynced := []cache.InformerSynced{
 				sc.pdbInformer.Informer().HasSynced,
 				sc.podInformer.Informer().HasSynced,
-				sc.podGroupInformer.Informer().HasSynced,
+				sc.podGroupInformerv1alpha1.Informer().HasSynced,
+				sc.podGroupInformerv1alpha2.Informer().HasSynced,
 				sc.nodeInformer.Informer().HasSynced,
 				sc.pvInformer.Informer().HasSynced,
 				sc.pvcInformer.Informer().HasSynced,
@@ -398,7 +443,23 @@ func (sc *SchedulerCache) Evict(taskInfo *kbapi.TaskInfo, reason string) error {
 	}()
 
 	if !shadowPodGroup(job.PodGroup) {
-		sc.Recorder.Eventf(job.PodGroup, v1.EventTypeNormal, "Evict", reason)
+		if job.PodGroup.Version == api.PodGroupVersionV1Alpha1 {
+			pg, err := api.ConvertPodGroupInfoToV1Alpha(job.PodGroup)
+			if err != nil {
+				glog.Errorf("Error While converting api.PodGroup to v1alpha.PodGroup with error: %v", err)
+				return err
+			}
+			sc.Recorder.Eventf(pg, v1.EventTypeNormal, "Evict", reason)
+		} else if job.PodGroup.Version == api.PodGroupVersionV1Alpha2 {
+			pg, err := api.ConvertPodGroupInfoToV2Alpha(job.PodGroup)
+			if err != nil {
+				glog.Errorf("Error While converting api.PodGroup to v2alpha.PodGroup with error: %v", err)
+				return err
+			}
+			sc.Recorder.Eventf(pg, v1.EventTypeNormal, "Evict", reason)
+		} else {
+			return fmt.Errorf("Invalid PodGroup Version: %s", job.PodGroup.Version)
+		}
 	}
 
 	return nil
@@ -632,16 +693,32 @@ func (sc *SchedulerCache) RecordJobStatusEvent(job *kbapi.JobInfo) {
 
 	if !shadowPodGroup(job.PodGroup) {
 		pgUnschedulable := job.PodGroup != nil &&
-			(job.PodGroup.Status.Phase == v1alpha1.PodGroupUnknown ||
-				job.PodGroup.Status.Phase == v1alpha1.PodGroupPending)
+			(job.PodGroup.Status.Phase == api.PodGroupUnknown ||
+				job.PodGroup.Status.Phase == api.PodGroupPending)
 		pdbUnschedulabe := job.PDB != nil && len(job.TaskStatusIndex[api.Pending]) != 0
 
 		// If pending or unschedulable, record unschedulable event.
 		if pgUnschedulable || pdbUnschedulabe {
 			msg := fmt.Sprintf("%v/%v tasks in gang unschedulable: %v",
 				len(job.TaskStatusIndex[api.Pending]), len(job.Tasks), job.FitError())
-			sc.Recorder.Eventf(job.PodGroup, v1.EventTypeWarning,
-				string(v1alpha1.PodGroupUnschedulableType), msg)
+
+			if job.PodGroup.Version == api.PodGroupVersionV1Alpha1 {
+				podGroup, err := api.ConvertPodGroupInfoToV1Alpha(job.PodGroup)
+				if err != nil {
+					glog.Errorf("Error while converting PodGroup to v1alpha1.PodGroup with error: %v", err)
+				}
+				sc.Recorder.Eventf(podGroup, v1.EventTypeWarning,
+					string(v1alpha1.PodGroupUnschedulableType), msg)
+			}
+
+			if job.PodGroup.Version == api.PodGroupVersionV1Alpha2 {
+				podGroup, err := api.ConvertPodGroupInfoToV2Alpha(job.PodGroup)
+				if err != nil {
+					glog.Errorf("Error while converting PodGroup to v1alpha2.PodGroup with error: %v", err)
+				}
+				sc.Recorder.Eventf(podGroup, v1.EventTypeWarning,
+					string(v1alpha1.PodGroupUnschedulableType), msg)
+			}
 		}
 	}
 
@@ -659,7 +736,7 @@ func (sc *SchedulerCache) RecordJobStatusEvent(job *kbapi.JobInfo) {
 // UpdateJobStatus update the status of job and its tasks.
 func (sc *SchedulerCache) UpdateJobStatus(job *kbapi.JobInfo) (*kbapi.JobInfo, error) {
 	if !shadowPodGroup(job.PodGroup) {
-		pg, err := sc.StatusUpdater.UpdatePodGroup(job.PodGroup)
+		pg, err := sc.StatusUpdater.UpdatePodGroup((job.PodGroup))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/scheduler/cache/event_handlers.go
+++ b/pkg/scheduler/cache/event_handlers.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cache
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/golang/glog"
@@ -29,7 +30,9 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	kbv1 "github.com/kubernetes-sigs/kube-batch/pkg/apis/scheduling/v1alpha1"
+	kbv2 "github.com/kubernetes-sigs/kube-batch/pkg/apis/scheduling/v1alpha2"
 	"github.com/kubernetes-sigs/kube-batch/pkg/apis/utils"
+	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler/api"
 	kbapi "github.com/kubernetes-sigs/kube-batch/pkg/scheduler/api"
 )
 
@@ -359,12 +362,12 @@ func (sc *SchedulerCache) DeleteNode(obj interface{}) {
 	return
 }
 
-func getJobID(pg *kbv1.PodGroup) kbapi.JobID {
+func getJobID(pg *api.PodGroup) kbapi.JobID {
 	return kbapi.JobID(fmt.Sprintf("%s/%s", pg.Namespace, pg.Name))
 }
 
 // Assumes that lock is already acquired.
-func (sc *SchedulerCache) setPodGroup(ss *kbv1.PodGroup) error {
+func (sc *SchedulerCache) setPodGroup(ss *api.PodGroup) error {
 	job := getJobID(ss)
 
 	if len(job) == 0 {
@@ -386,12 +389,12 @@ func (sc *SchedulerCache) setPodGroup(ss *kbv1.PodGroup) error {
 }
 
 // Assumes that lock is already acquired.
-func (sc *SchedulerCache) updatePodGroup(oldQueue, newQueue *kbv1.PodGroup) error {
+func (sc *SchedulerCache) updatePodGroup(oldQueue, newQueue *api.PodGroup) error {
 	return sc.setPodGroup(newQueue)
 }
 
 // Assumes that lock is already acquired.
-func (sc *SchedulerCache) deletePodGroup(ss *kbv1.PodGroup) error {
+func (sc *SchedulerCache) deletePodGroup(ss *api.PodGroup) error {
 	jobID := getJobID(ss)
 
 	job, found := sc.Jobs[jobID]
@@ -407,19 +410,32 @@ func (sc *SchedulerCache) deletePodGroup(ss *kbv1.PodGroup) error {
 	return nil
 }
 
-// AddPodGroup add podgroup to scheduler cache
-func (sc *SchedulerCache) AddPodGroup(obj interface{}) {
+// AddPodGroupAlpha1 add podgroup to scheduler cache
+func (sc *SchedulerCache) AddPodGroupAlpha1(obj interface{}) {
 	ss, ok := obj.(*kbv1.PodGroup)
 	if !ok {
 		glog.Errorf("Cannot convert to *kbv1.PodGroup: %v", obj)
 		return
 	}
 
+	marshalled, err := json.Marshal(*ss)
+	if err != nil {
+		glog.Errorf("Failed to Marshal podgroup %s with error: %v", ss.Name, err)
+	}
+
+	pg := &api.PodGroup{}
+	err = json.Unmarshal(marshalled, pg)
+	if err != nil {
+		glog.Errorf("Failed to Unmarshal Data into api.PodGroup type with error: %v", err)
+	}
+	pg.Version = api.PodGroupVersionV1Alpha1
+
 	sc.Mutex.Lock()
 	defer sc.Mutex.Unlock()
 
 	glog.V(4).Infof("Add PodGroup(%s) into cache, spec(%#v)", ss.Name, ss.Spec)
-	err := sc.setPodGroup(ss)
+
+	err = sc.setPodGroup(pg)
 	if err != nil {
 		glog.Errorf("Failed to add PodGroup %s into cache: %v", ss.Name, err)
 		return
@@ -427,8 +443,41 @@ func (sc *SchedulerCache) AddPodGroup(obj interface{}) {
 	return
 }
 
-// UpdatePodGroup add podgroup to scheduler cache
-func (sc *SchedulerCache) UpdatePodGroup(oldObj, newObj interface{}) {
+// AddPodGroupAlpha2 add podgroup to scheduler cache
+func (sc *SchedulerCache) AddPodGroupAlpha2(obj interface{}) {
+	ss, ok := obj.(*kbv2.PodGroup)
+	if !ok {
+		glog.Errorf("Cannot convert to *kbv2.PodGroup: %v", obj)
+		return
+	}
+
+	marshalled, err := json.Marshal(*ss)
+	if err != nil {
+		glog.Errorf("Failed to Marshal podgroup %s with error: %v", ss.Name, err)
+	}
+
+	pg := &api.PodGroup{}
+	err = json.Unmarshal(marshalled, pg)
+	if err != nil {
+		glog.Errorf("Failed to Unmarshal Data into api.PodGroup type with error: %v", err)
+	}
+	pg.Version = api.PodGroupVersionV1Alpha2
+
+	sc.Mutex.Lock()
+	defer sc.Mutex.Unlock()
+
+	glog.V(4).Infof("Add PodGroup(%s) into cache, spec(%#v)", ss.Name, ss.Spec)
+
+	err = sc.setPodGroup(pg)
+	if err != nil {
+		glog.Errorf("Failed to add PodGroup %s into cache: %v", ss.Name, err)
+		return
+	}
+	return
+}
+
+// UpdatePodGroupAlpha1 add podgroup to scheduler cache
+func (sc *SchedulerCache) UpdatePodGroupAlpha1(oldObj, newObj interface{}) {
 	oldSS, ok := oldObj.(*kbv1.PodGroup)
 	if !ok {
 		glog.Errorf("Cannot convert oldObj to *kbv1.SchedulingSpec: %v", oldObj)
@@ -440,10 +489,36 @@ func (sc *SchedulerCache) UpdatePodGroup(oldObj, newObj interface{}) {
 		return
 	}
 
+	oldMarshalled, err := json.Marshal(*oldSS)
+	if err != nil {
+		glog.Errorf("Failed to Marshal podgroup %s with error: %v", oldSS.Name, err)
+	}
+
+	oldPg := &api.PodGroup{}
+	oldPg.Version = api.PodGroupVersionV1Alpha1
+
+	err = json.Unmarshal(oldMarshalled, oldPg)
+	if err != nil {
+		glog.Errorf("Failed to Unmarshal Data into api.PodGroup type with error: %v", err)
+	}
+
+	newMarshalled, err := json.Marshal(*newSS)
+	if err != nil {
+		glog.Errorf("Failed to Marshal podgroup %s with error: %v", newSS.Name, err)
+	}
+
+	newPg := &api.PodGroup{}
+	newPg.Version = api.PodGroupVersionV1Alpha1
+
+	err = json.Unmarshal(newMarshalled, newPg)
+	if err != nil {
+		glog.Errorf("Failed to Unmarshal Data into api.PodGroup type with error: %v", err)
+	}
+
 	sc.Mutex.Lock()
 	defer sc.Mutex.Unlock()
 
-	err := sc.updatePodGroup(oldSS, newSS)
+	err = sc.updatePodGroup(oldPg, newPg)
 	if err != nil {
 		glog.Errorf("Failed to update SchedulingSpec %s into cache: %v", oldSS.Name, err)
 		return
@@ -451,8 +526,58 @@ func (sc *SchedulerCache) UpdatePodGroup(oldObj, newObj interface{}) {
 	return
 }
 
-// DeletePodGroup delete podgroup from scheduler cache
-func (sc *SchedulerCache) DeletePodGroup(obj interface{}) {
+// UpdatePodGroupAlpha2 add podgroup to scheduler cache
+func (sc *SchedulerCache) UpdatePodGroupAlpha2(oldObj, newObj interface{}) {
+	oldSS, ok := oldObj.(*kbv2.PodGroup)
+	if !ok {
+		glog.Errorf("Cannot convert oldObj to *kbv2.SchedulingSpec: %v", oldObj)
+		return
+	}
+	newSS, ok := newObj.(*kbv2.PodGroup)
+	if !ok {
+		glog.Errorf("Cannot convert newObj to *kbv2.SchedulingSpec: %v", newObj)
+		return
+	}
+
+	oldMarshalled, err := json.Marshal(*oldSS)
+	if err != nil {
+		glog.Errorf("Failed to Marshal podgroup %s with error: %v", oldSS.Name, err)
+	}
+
+	oldPg := &api.PodGroup{}
+	oldPg.Version = api.PodGroupVersionV1Alpha2
+
+	err = json.Unmarshal(oldMarshalled, oldPg)
+	if err != nil {
+		glog.Errorf("Failed to Unmarshal Data into api.PodGroup type with error: %v", err)
+	}
+
+	newMarshalled, err := json.Marshal(*newSS)
+	if err != nil {
+		glog.Errorf("Failed to Marshal podgroup %s with error: %v", newSS.Name, err)
+	}
+
+	newPg := &api.PodGroup{}
+	newPg.Version = api.PodGroupVersionV1Alpha2
+
+	err = json.Unmarshal(newMarshalled, newPg)
+	if err != nil {
+		glog.Errorf("Failed to Unmarshal Data into api.PodGroup type with error: %v", err)
+	}
+
+	sc.Mutex.Lock()
+	defer sc.Mutex.Unlock()
+
+	err = sc.updatePodGroup(oldPg, newPg)
+	if err != nil {
+		glog.Errorf("Failed to update SchedulingSpec %s into cache: %v", oldSS.Name, err)
+		return
+	}
+	return
+}
+
+// DeletePodGroupAlpha1 delete podgroup from scheduler cache
+func (sc *SchedulerCache) DeletePodGroupAlpha1(obj interface{}) {
 	var ss *kbv1.PodGroup
 	switch t := obj.(type) {
 	case *kbv1.PodGroup:
@@ -469,10 +594,63 @@ func (sc *SchedulerCache) DeletePodGroup(obj interface{}) {
 		return
 	}
 
+	marshalled, err := json.Marshal(*ss)
+	if err != nil {
+		glog.Errorf("Failed to Marshal podgroup %s with error: %v", ss.Name, err)
+	}
+
+	pg := &api.PodGroup{}
+	pg.Version = api.PodGroupVersionV1Alpha1
+	err = json.Unmarshal(marshalled, pg)
+	if err != nil {
+		glog.Errorf("Failed to Unmarshal Data into api.PodGroup type with error: %v", err)
+	}
+
 	sc.Mutex.Lock()
 	defer sc.Mutex.Unlock()
 
-	err := sc.deletePodGroup(ss)
+	err = sc.deletePodGroup(pg)
+	if err != nil {
+		glog.Errorf("Failed to delete SchedulingSpec %s from cache: %v", ss.Name, err)
+		return
+	}
+	return
+}
+
+// DeletePodGroupAlpha2 delete podgroup from scheduler cache
+func (sc *SchedulerCache) DeletePodGroupAlpha2(obj interface{}) {
+	var ss *kbv2.PodGroup
+	switch t := obj.(type) {
+	case *kbv2.PodGroup:
+		ss = t
+	case cache.DeletedFinalStateUnknown:
+		var ok bool
+		ss, ok = t.Obj.(*kbv2.PodGroup)
+		if !ok {
+			glog.Errorf("Cannot convert to *kbv2.SchedulingSpec: %v", t.Obj)
+			return
+		}
+	default:
+		glog.Errorf("Cannot convert to *kbv2.SchedulingSpec: %v", t)
+		return
+	}
+
+	marshalled, err := json.Marshal(*ss)
+	if err != nil {
+		glog.Errorf("Failed to Marshal podgroup %s with error: %v", ss.Name, err)
+	}
+
+	pg := &api.PodGroup{}
+	pg.Version = api.PodGroupVersionV1Alpha2
+	err = json.Unmarshal(marshalled, pg)
+	if err != nil {
+		glog.Errorf("Failed to Unmarshal Data into api.PodGroup type with error: %v", err)
+	}
+
+	sc.Mutex.Lock()
+	defer sc.Mutex.Unlock()
+
+	err = sc.deletePodGroup(pg)
 	if err != nil {
 		glog.Errorf("Failed to delete SchedulingSpec %s from cache: %v", ss.Name, err)
 		return

--- a/pkg/scheduler/cache/interface.go
+++ b/pkg/scheduler/cache/interface.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cache
 
 import (
-	"github.com/kubernetes-sigs/kube-batch/pkg/apis/scheduling/v1alpha1"
 	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler/api"
 	v1 "k8s.io/api/core/v1"
 )
@@ -74,5 +73,5 @@ type Evictor interface {
 // StatusUpdater updates pod with given PodCondition
 type StatusUpdater interface {
 	UpdatePodCondition(pod *v1.Pod, podCondition *v1.PodCondition) (*v1.Pod, error)
-	UpdatePodGroup(pg *v1alpha1.PodGroup) (*v1alpha1.PodGroup, error)
+	UpdatePodGroup(pg *api.PodGroup) (*api.PodGroup, error)
 }

--- a/pkg/scheduler/cache/util.go
+++ b/pkg/scheduler/cache/util.go
@@ -20,7 +20,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/kubernetes-sigs/kube-batch/pkg/apis/scheduling/v1alpha1"
 	"github.com/kubernetes-sigs/kube-batch/pkg/apis/utils"
 	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler/api"
 )
@@ -29,7 +28,7 @@ const (
 	shadowPodGroupKey = "volcano/shadow-pod-group"
 )
 
-func shadowPodGroup(pg *v1alpha1.PodGroup) bool {
+func shadowPodGroup(pg *api.PodGroup) bool {
 	if pg == nil {
 		return true
 	}
@@ -39,13 +38,13 @@ func shadowPodGroup(pg *v1alpha1.PodGroup) bool {
 	return found
 }
 
-func createShadowPodGroup(pod *v1.Pod) *v1alpha1.PodGroup {
+func createShadowPodGroup(pod *v1.Pod) *api.PodGroup {
 	jobID := api.JobID(utils.GetController(pod))
 	if len(jobID) == 0 {
 		jobID = api.JobID(pod.UID)
 	}
 
-	return &v1alpha1.PodGroup{
+	return &api.PodGroup{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: pod.Namespace,
 			Name:      string(jobID),
@@ -53,7 +52,7 @@ func createShadowPodGroup(pod *v1.Pod) *v1alpha1.PodGroup {
 				shadowPodGroupKey: string(jobID),
 			},
 		},
-		Spec: v1alpha1.PodGroupSpec{
+		Spec: api.PodGroupSpec{
 			MinMember: 1,
 		},
 	}

--- a/pkg/scheduler/plugins/gang/gang.go
+++ b/pkg/scheduler/plugins/gang/gang.go
@@ -142,8 +142,8 @@ func (gp *gangPlugin) OnSessionClose(ssn *framework.Session) {
 			metrics.UpdateUnscheduleTaskCount(job.Name, int(unreadyTaskCount))
 			metrics.RegisterJobRetries(job.Name)
 
-			jc := &v1alpha1.PodGroupCondition{
-				Type:               v1alpha1.PodGroupUnschedulableType,
+			jc := &api.PodGroupCondition{
+				Type:               api.PodGroupUnschedulableType,
 				Status:             v1.ConditionTrue,
 				LastTransitionTime: metav1.Now(),
 				TransitionID:       string(ssn.UID),

--- a/pkg/scheduler/util/test_utils.go
+++ b/pkg/scheduler/util/test_utils.go
@@ -143,7 +143,7 @@ func (ftsu *FakeStatusUpdater) UpdatePodCondition(pod *v1.Pod, podCondition *v1.
 }
 
 // UpdatePodGroup is a empty function
-func (ftsu *FakeStatusUpdater) UpdatePodGroup(pg *kbv1.PodGroup) (*kbv1.PodGroup, error) {
+func (ftsu *FakeStatusUpdater) UpdatePodGroup(pg *api.PodGroup) (*api.PodGroup, error) {
 	// do nothing here
 	return nil, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Add v1alpha2 PodGroup version in kube-batch, so user can create PodGroup in v1alpha2 version and kube-batch can schedule pods related to that PodGroup.
**Which issue(s) this PR fixes**:
https://github.com/kubernetes-sigs/kube-batch/issues/866


