### PR TITLE
Remove the useless namespace

### DIFF
--- a/doc/usage/tutorial.md
+++ b/doc/usage/tutorial.md
@@ -164,7 +164,6 @@ apiVersion: scheduling.k8s.io/v1beta1
 kind: PriorityClass
 metadata:
   name: high-priority
-  namespace: batch-ns01
 value: 1000
 ```
 


### PR DESCRIPTION
**What this PR does / why we need it**:

PriorityClasses are not namespaced.

**Release note**:

```release-note
NONE
```

