### PR TITLE
fix reclaim ping-pong

### DIFF
--- a/pkg/scheduler/framework/session_plugins.go
+++ b/pkg/scheduler/framework/session_plugins.go
@@ -76,7 +76,7 @@ func (ssn *Session) AddJobValidFn(name string, fn api.ValidateExFn) {
 	ssn.jobValidFns[name] = fn
 }
 
-// Reclaimable invoke reclaimable function of the plugins
+// Reclaimable invoke reclaimable function of the plugins, only the victims that meet all the plugins can be reclaimed.
 func (ssn *Session) Reclaimable(reclaimer *api.TaskInfo, reclaimees []*api.TaskInfo) []*api.TaskInfo {
 	var victims []*api.TaskInfo
 	var init bool
@@ -109,10 +109,7 @@ func (ssn *Session) Reclaimable(reclaimer *api.TaskInfo, reclaimees []*api.TaskI
 				victims = intersection
 			}
 		}
-		// Plugins in this tier made decision if victims is not nil
-		if victims != nil {
-			return victims
-		}
+		// Just continue the loop here to go through all plugins
 	}
 
 	return victims

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -22,7 +22,7 @@ import (
 	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler/api"
 	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler/api/helpers"
 	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler/framework"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/scheduler/cache"
 )
 

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -66,7 +66,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 		ignore := false
 		for i := range taints {
 			t := taints[i]
-			if(t.Effect == v1.TaintEffectNoSchedule || t.Effect == v1.TaintEffectNoExecute) {
+			if t.Effect == v1.TaintEffectNoSchedule || t.Effect == v1.TaintEffectNoExecute {
 				ignore = true
 				glog.V(3).Infof("Ingore host <%v>,  %v.", n.Name, t)
 				break


### PR DESCRIPTION
**What this PR does / why we need it**:
There is a ping-pong for reclaim.

The env:
1. build a k8s cluster with 2 hosts, each host has 8 cpu.
2. build a job (job1) with 1 container for 6 cpu, and another job (job2) in another queue with 1 container for 6 cpu.
3. job2 will reclaim job1.
4. the reclaimed res is assigned to job1 again.

step 3 and 4 will be repeated, ping-pong happens.

**Special notes for your reviewer**:
The current reclaim behavior is wrong, and there is similar error for preemption. Let's fix them step by step, just handle the reclaim case here.

In this case, the changed parts are:
1: Ignore the master host when calculating the deserved resource since it cannot be used at all. With this, we can get the correct deserved resource.
2: Change the plug-in behavior for reclaim. Reclaim will not happen unless it passes all the plug-in's check. This make sense to me as if reclaim can happen when it can pass part of the plug-ins, this will break the rule of other plug-ins (it is proportion in this case), and the broken plug-in will break the reclaim behavior later, this is why ping-pong happens.

**Release note**:
```release-note
Reclaim ping-pong issue resolved.
```

