### PR TITLE
add shadowGroup's CreationTimestamp

### DIFF
--- a/pkg/scheduler/cache/util.go
+++ b/pkg/scheduler/cache/util.go
@@ -51,6 +51,7 @@ func createShadowPodGroup(pod *v1.Pod) *api.PodGroup {
 			Annotations: map[string]string{
 				shadowPodGroupKey: string(jobID),
 			},
+			CreationTimestamp: pod.CreationTimestamp,
 		},
 		Spec: api.PodGroupSpec{
 			MinMember: 1,


### PR DESCRIPTION
when it comes a pod without its podgroup,kube-batch create its shadowgroup,but this podgroup's creationtimestamp uses the Type Time's default value,i think the pod's creationtimestamp is more properly