### PR TITLE
added priority based preemption to priority plugin

### DIFF
--- a/pkg/scheduler/plugins/gang/gang.go
+++ b/pkg/scheduler/plugins/gang/gang.go
@@ -77,14 +77,14 @@ func (gp *gangPlugin) OnSessionOpen(ssn *framework.Session) {
 			preemptable := job.MinAvailable <= occupid-1 || job.MinAvailable == 1
 
 			if !preemptable {
-				glog.V(3).Infof("Can not preempt task <%v/%v> because of gang-scheduling",
+				glog.V(4).Infof("Can not preempt task <%v/%v> because of gang-scheduling",
 					preemptee.Namespace, preemptee.Name)
 			} else {
 				victims = append(victims, preemptee)
 			}
 		}
 
-		glog.V(3).Infof("Victims from Gang plugins are %+v", victims)
+		glog.V(4).Infof("Victims from Gang plugins are %+v", victims)
 
 		return victims
 	}

--- a/pkg/scheduler/plugins/priority/priority.go
+++ b/pkg/scheduler/plugins/priority/priority.go
@@ -85,7 +85,7 @@ func (pp *priorityPlugin) OnSessionOpen(ssn *framework.Session) {
 		for _, preemptee := range preemptees {
 			preempteeJob := ssn.Jobs[preemptee.Job]
 			if preempteeJob.Priority >= preemptorJob.Priority {
-				glog.V(3).Infof("Can not preempt task <%v/%v> because "+
+				glog.V(4).Infof("Can not preempt task <%v/%v> because "+
 					"preemptee has greater or equal job priority (%d) than preemptor (%d)",
 					preemptee.Namespace, preemptee.Name, preempteeJob.Priority, preemptorJob.Priority)
 			} else {
@@ -93,7 +93,7 @@ func (pp *priorityPlugin) OnSessionOpen(ssn *framework.Session) {
 			}
 		}
 
-		glog.V(3).Infof("Victims from Priority plugins are %+v", victims)
+		glog.V(4).Infof("Victims from Priority plugins are %+v", victims)
 		return victims
 	}
 

--- a/pkg/scheduler/plugins/priority/priority.go
+++ b/pkg/scheduler/plugins/priority/priority.go
@@ -77,6 +77,27 @@ func (pp *priorityPlugin) OnSessionOpen(ssn *framework.Session) {
 	}
 
 	ssn.AddJobOrderFn(pp.Name(), jobOrderFn)
+
+	preemptableFn := func(preemptor *api.TaskInfo, preemptees []*api.TaskInfo) []*api.TaskInfo {
+		preemptorJob := ssn.Jobs[preemptor.Job]
+
+		var victims []*api.TaskInfo
+		for _, preemptee := range preemptees {
+			preempteeJob := ssn.Jobs[preemptee.Job]
+			if preempteeJob.Priority >= preemptorJob.Priority {
+				glog.V(3).Infof("Can not preempt task <%v/%v> because "+
+					"preemptee has greater or equal job priority (%d) than preemptor (%d)",
+					preemptee.Namespace, preemptee.Name, preempteeJob.Priority, preemptorJob.Priority)
+			} else {
+				victims = append(victims, preemptee)
+			}
+		}
+
+		glog.V(3).Infof("Victims from Priority plugins are %+v", victims)
+		return victims
+	}
+
+	ssn.AddPreemptableFn(pp.Name(), preemptableFn)
 }
 
 func (pp *priorityPlugin) OnSessionClose(ssn *framework.Session) {}

--- a/test/e2e/job.go
+++ b/test/e2e/job.go
@@ -165,11 +165,13 @@ var _ = Describe("Job E2E Test", func() {
 		}
 
 		job.name = "preemptee-qj"
+		job.pri = workerPriority
 		_, pg1 := createJob(context, job)
 		err := waitTasksReady(context, pg1, int(rep))
 		checkError(context, err)
 
 		job.name = "preemptor-qj"
+		job.pri = masterPriority
 		_, pg2 := createJob(context, job)
 		err = waitTasksReady(context, pg1, int(rep)/2)
 		checkError(context, err)
@@ -197,15 +199,18 @@ var _ = Describe("Job E2E Test", func() {
 		}
 
 		job.name = "preemptee-qj"
+		job.pri = workerPriority
 		_, pg1 := createJob(context, job)
 		err := waitTasksReady(context, pg1, int(rep))
 		checkError(context, err)
 
 		job.name = "preemptor-qj1"
+		job.pri = masterPriority
 		_, pg2 := createJob(context, job)
 		checkError(context, err)
 
 		job.name = "preemptor-qj2"
+		job.pri = masterPriority
 		_, pg3 := createJob(context, job)
 		checkError(context, err)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Priority plugin now adds preemptable function which makes preemptee a victim if and only if job priority of the preemptee is strictly lower than job priority of the preemptor.

This is consistent with default behavior of the standard kubernetes scheduler: if a Pod cannot be scheduled, the scheduler tries to preempt (evict) lower priority Pods to make scheduling of the pending Pod possible (see https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/).

To disable this functionality use `enablePreemptable: false` in the `priority` plugin configuration.

Closes kubernetes-sigs/kube-batch#894

**Which issue(s) this PR fixes** :
Fixes #894

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Priority plugin now adds preemptable function which makes preemptee a victim if and only if job priority of the preemptee is strictly lower than job priority of the preemptor. To disable this functionality use `enablePreemptable: false` in the `priority` plugin configuration.
```

