### PR TITLE
derive shadow pod group priority from pod priority

### DIFF
--- a/pkg/scheduler/cache/util.go
+++ b/pkg/scheduler/cache/util.go
@@ -53,7 +53,8 @@ func createShadowPodGroup(pod *v1.Pod) *api.PodGroup {
 			},
 		},
 		Spec: api.PodGroupSpec{
-			MinMember: 1,
+			MinMember:         1,
+			PriorityClassName: pod.Spec.PriorityClassName,
 		},
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Shadow pod group priority should match priority of the pod it was created from.
This matches behavior of the volcano controller, see https://github.com/volcano-sh/volcano/blob/master/pkg/controllers/podgroup/pg_controller_handler.go#L90.

**Which issue(s) this PR fixes**:
Fixes #905

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Shadow pod group priority matches priority of the pod it was created from.
```

