### PR TITLE
shadow pod group derives min member from pod annotations

### DIFF
--- a/pkg/apis/scheduling/v1alpha1/labels.go
+++ b/pkg/apis/scheduling/v1alpha1/labels.go
@@ -19,3 +19,10 @@ package v1alpha1
 // GroupNameAnnotationKey is the annotation key of Pod to identify
 // which PodGroup it belongs to.
 const GroupNameAnnotationKey = "scheduling.k8s.io/group-name"
+
+// GroupMinMemberAnnotationKey is the annotation key of Pod to specify
+// the minimal number of members/tasks to run the pod group with.
+//
+// If Pod has GroupNameAnnotationKey annotation specified,
+// then min member value specified in the aforementioned PodGroup will be used instead.
+const GroupMinMemberAnnotationKey = "scheduling.k8s.io/group-min-member"

--- a/pkg/apis/scheduling/v1alpha2/labels.go
+++ b/pkg/apis/scheduling/v1alpha2/labels.go
@@ -19,3 +19,10 @@ package v1alpha2
 // GroupNameAnnotationKey is the annotation key of Pod to identify
 // which PodGroup it belongs to.
 const GroupNameAnnotationKey = "scheduling.k8s.io/group-name"
+
+// GroupMinMemberAnnotationKey is the annotation key of Pod to specify
+// the minimal number of members/tasks to run the pod group with.
+//
+// If Pod has GroupNameAnnotationKey annotation specified,
+// then min member value specified in the aforementioned PodGroup will be used instead.
+const GroupMinMemberAnnotationKey = "scheduling.k8s.io/group-min-member"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Added `scheduling.k8s.io/group-min-member` annotation that allows to specify min member for the shadow pod group.

Requiring users to learn new custom resource `PodGroup` and properly handling clean up of such resource is nontrivial and time consuming. In common use case user just want create a batch of pods that will be allocated together at the same time. Extending shadow pod group capabilities could be a solution for this.

**Which issue(s) this PR fixes**:
Fixes #905 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Shadow pod group has min member derived from the pod annotation "scheduling.k8s.io/group-min-member". This is backward compatible change - if annotation is not specified, then min member defaults to 1. If pod has normal pod group, then this annotation will be ignored, and min member from the pod group object will be used instead.
```

