### PR TITLE
revert cache to original state on evict and bind errors

### DIFF
--- a/pkg/scheduler/api/node_info.go
+++ b/pkg/scheduler/api/node_info.go
@@ -163,15 +163,18 @@ func (ni *NodeInfo) allocateIdleResource(ti *TaskInfo) error {
 		ni.Idle.Sub(ti.Resreq)
 		return nil
 	}
-	ni.State = NodeState{
-		Phase:  NotReady,
-		Reason: "OutOfSync",
-	}
 	return fmt.Errorf("Selected node NotReady")
 }
 
 // AddTask is used to add a task in nodeInfo object
+//
+// If error occurs both task and node are guaranteed to be in the original state.
 func (ni *NodeInfo) AddTask(task *TaskInfo) error {
+	if len(task.NodeName) > 0 && len(ni.Name) > 0 && task.NodeName != ni.Name {
+		return fmt.Errorf("task <%v/%v> already on different node <%v>",
+			task.Namespace, task.Name, task.NodeName)
+	}
+
 	key := PodKey(task.Pod)
 	if _, found := ni.Tasks[key]; found {
 		return fmt.Errorf("task <%v/%v> already on node <%v>",
@@ -200,12 +203,17 @@ func (ni *NodeInfo) AddTask(task *TaskInfo) error {
 		ni.Used.Add(ti.Resreq)
 	}
 
+	// Update task node name upon successful task addition.
+	task.NodeName = ni.Name
+	ti.NodeName = ni.Name
 	ni.Tasks[key] = ti
 
 	return nil
 }
 
-// RemoveTask used to remove a task from nodeInfo object
+// RemoveTask used to remove a task from nodeInfo object.
+//
+// If error occurs both task and node are guaranteed to be in the original state.
 func (ni *NodeInfo) RemoveTask(ti *TaskInfo) error {
 	key := PodKey(ti.Pod)
 
@@ -234,13 +242,20 @@ func (ni *NodeInfo) RemoveTask(ti *TaskInfo) error {
 	return nil
 }
 
-// UpdateTask is used to update a task in nodeInfo object
+// UpdateTask is used to update a task in nodeInfo object.
+//
+// If error occurs both task and node are guaranteed to be in the original state.
 func (ni *NodeInfo) UpdateTask(ti *TaskInfo) error {
 	if err := ni.RemoveTask(ti); err != nil {
 		return err
 	}
-
-	return ni.AddTask(ti)
+	if err := ni.AddTask(ti); err != nil {
+		// This should never happen if task removal was successful,
+		// because only possible error during task addition is when task is still on a node.
+		glog.Fatalf("Failed to add Task <%s,%s> to Node <%s> during task update",
+			ti.Namespace, ti.Name, ni.Name)
+	}
+	return nil
 }
 
 // String returns nodeInfo details in string format

--- a/pkg/scheduler/api/node_info_test.go
+++ b/pkg/scheduler/api/node_info_test.go
@@ -42,10 +42,11 @@ func TestNodeInfo_AddPod(t *testing.T) {
 	case02Pod1 := buildPod("c2", "p1", "n2", v1.PodUnknown, buildResourceList("1000m", "2G"), []metav1.OwnerReference{}, make(map[string]string))
 
 	tests := []struct {
-		name     string
-		node     *v1.Node
-		pods     []*v1.Pod
-		expected *NodeInfo
+		name            string
+		node            *v1.Node
+		pods            []*v1.Pod
+		expected        *NodeInfo
+		expectedFailure bool
 	}{
 		{
 			name: "add 2 running non-owner pod",
@@ -78,9 +79,10 @@ func TestNodeInfo_AddPod(t *testing.T) {
 				Releasing:   EmptyResource(),
 				Allocatable: buildResource("2000m", "1G"),
 				Capability:  buildResource("2000m", "1G"),
-				State:       NodeState{Phase: NotReady, Reason: "OutOfSync"},
+				State:       NodeState{Phase: Ready},
 				Tasks:       map[TaskID]*TaskInfo{},
 			},
+			expectedFailure: true,
 		},
 	}
 
@@ -89,7 +91,13 @@ func TestNodeInfo_AddPod(t *testing.T) {
 
 		for _, pod := range test.pods {
 			pi := NewTaskInfo(pod)
-			ni.AddTask(pi)
+			err := ni.AddTask(pi)
+			if err != nil && !test.expectedFailure {
+				t.Errorf("node info %d: \n expected success, \n but got err %v \n", i, err)
+			}
+			if err == nil && test.expectedFailure {
+				t.Errorf("node info %d: \n expected failure, \n but got success \n", i)
+			}
 		}
 
 		if !nodeInfoEqual(ni, test.expected) {

--- a/pkg/scheduler/cache/cache_test.go
+++ b/pkg/scheduler/cache/cache_test.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/kubernetes-sigs/kube-batch/pkg/scheduler/util"
 	v1 "k8s.io/api/core/v1"
 	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -359,5 +360,77 @@ func TestGetOrCreateJob(t *testing.T) {
 			t.Errorf("case %d: \n expected %t, \n got %t \n",
 				i, test.gotJob, result)
 		}
+	}
+}
+
+func TestSchedulerCache_Bind_NodeWithSufficientResources(t *testing.T) {
+	owner := buildOwnerReference("j1")
+
+	cache := &SchedulerCache{
+		Jobs:  make(map[api.JobID]*api.JobInfo),
+		Nodes: make(map[string]*api.NodeInfo),
+		Binder: &util.FakeBinder{
+			Binds:   map[string]string{},
+			Channel: make(chan string),
+		},
+	}
+
+	pod := buildPod("c1", "p1", "", v1.PodPending, buildResourceList("1000m", "1G"),
+		[]metav1.OwnerReference{owner}, make(map[string]string))
+	cache.AddPod(pod)
+
+	node := buildNode("n1", buildResourceList("2000m", "10G"))
+	cache.AddNode(node)
+
+	task := api.NewTaskInfo(pod)
+	task.Job = "j1"
+
+	err := cache.Bind(task, "n1")
+	if err != nil {
+		t.Errorf("failed to bind pod to node: %v", err)
+	}
+}
+
+func TestSchedulerCache_Bind_NodeWithInsufficientResources(t *testing.T) {
+	owner := buildOwnerReference("j1")
+
+	cache := &SchedulerCache{
+		Jobs:  make(map[api.JobID]*api.JobInfo),
+		Nodes: make(map[string]*api.NodeInfo),
+		Binder: &util.FakeBinder{
+			Binds:   map[string]string{},
+			Channel: make(chan string),
+		},
+	}
+
+	pod := buildPod("c1", "p1", "", v1.PodPending, buildResourceList("5000m", "50G"),
+		[]metav1.OwnerReference{owner}, make(map[string]string))
+	cache.AddPod(pod)
+
+	node := buildNode("n1", buildResourceList("2000m", "10G"))
+	cache.AddNode(node)
+
+	task := api.NewTaskInfo(pod)
+	task.Job = "j1"
+
+	taskBeforeBind := task.Clone()
+	nodeBeforeBind := cache.Nodes["n1"].Clone()
+
+	err := cache.Bind(task, "n1")
+	if err == nil {
+		t.Errorf("expected bind to fail for node with insufficient resources")
+	}
+
+	_, taskAfterBind, err := cache.findJobAndTask(task)
+	if err != nil {
+		t.Errorf("expected to find task after failed bind")
+	}
+	if !reflect.DeepEqual(taskBeforeBind, taskAfterBind) {
+		t.Errorf("expected task to remain the same after failed bind")
+	}
+
+	nodeAfterBind := cache.Nodes["n1"]
+	if !reflect.DeepEqual(nodeBeforeBind, nodeAfterBind) {
+		t.Errorf("expected node to remain the same after failed bind")
 	}
 }

--- a/pkg/scheduler/cache/event_handlers.go
+++ b/pkg/scheduler/cache/event_handlers.go
@@ -77,7 +77,9 @@ func (sc *SchedulerCache) addTask(pi *kbapi.TaskInfo) error {
 
 	if len(pi.NodeName) != 0 {
 		if _, found := sc.Nodes[pi.NodeName]; !found {
-			sc.Nodes[pi.NodeName] = kbapi.NewNodeInfo(nil)
+			node := kbapi.NewNodeInfo(nil)
+			node.Name = pi.NodeName
+			sc.Nodes[pi.NodeName] = node
 		}
 
 		node := sc.Nodes[pi.NodeName]

--- a/pkg/scheduler/framework/session.go
+++ b/pkg/scheduler/framework/session.go
@@ -206,8 +206,6 @@ func (ssn *Session) Pipeline(task *api.TaskInfo, hostname string) error {
 		return fmt.Errorf("failed to find job %s when binding", task.Job)
 	}
 
-	task.NodeName = hostname
-
 	if node, found := ssn.Nodes[hostname]; found {
 		if err := node.AddTask(task); err != nil {
 			glog.Errorf("Failed to add task <%v/%v> to node <%v> in Session <%v>: %v",
@@ -252,8 +250,6 @@ func (ssn *Session) Allocate(task *api.TaskInfo, hostname string) error {
 			task.Job, ssn.UID)
 		return fmt.Errorf("failed to find job %s", task.Job)
 	}
-
-	task.NodeName = hostname
 
 	if node, found := ssn.Nodes[hostname]; found {
 		if err := node.AddTask(task); err != nil {

--- a/pkg/scheduler/framework/statement.go
+++ b/pkg/scheduler/framework/statement.go
@@ -123,8 +123,6 @@ func (s *Statement) Pipeline(task *api.TaskInfo, hostname string) error {
 			task.Job, s.ssn.UID)
 	}
 
-	task.NodeName = hostname
-
 	if node, found := s.ssn.Nodes[hostname]; found {
 		if err := node.AddTask(task); err != nil {
 			glog.Errorf("Failed to pipeline task <%v/%v> to node <%v> in Session <%v>: %v",


### PR DESCRIPTION
**What this PR does / why we need it**:
This change ensures that node, task and job info will remain unchanged in case of an error during SchedulerCache.Bind and SchedulerCache.Evict calls.
Before if error occurred during binding phase (e.g. "Selected node NotReady") task could get stuck in the Binding status indefinitely while the real pod would be in the Pending status.

- SchedulerCache.Evict and SchedulerCache.Bind will revert task status on NodeInfo.UpdateTask and NodeInfo.AddTask errors.
- Modified behavior of NodeInfo.AddTask. AddTask will now update task's node name upon successful addition, this is similar to how JobInfo.UpdateTaskStatus updates task's status.
- Handling unchecked error in JobInfo.UpdateTaskStatus.
- FATAL logging in NodeInfo.UpdateTask when impossible situation happens - failing to add a task after removal of a task from node info.

Might be related to #891.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

