### PR TITLE
Avoid pushing empty jobs into queue

### DIFF
--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -182,7 +182,7 @@ func (alloc *allocateAction) Execute(ssn *framework.Session) {
 				}
 			}
 
-			if ssn.JobReady(job) {
+			if ssn.JobReady(job) && !tasks.Empty() {
 				jobs.Push(job)
 				break
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Currently we may push am empty job back to its queue and that may slightly affect the performance.