### PR TITLE
Update community contact points to be SIG-Scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Learn how to engage with the Kubernetes community on the [community page](http:/
 
 You can reach the maintainers of this project at:
 
-- Slack: #kubernetes-dev
-- Mailing List: https://groups.google.com/forum/#!forum/kubernetes-dev
+- Slack: #sig-scheduling
+- Mailing List: https://groups.google.com/forum/#!forum/kubernetes-sig-scheduling
 
 ### Code of conduct
 


### PR DESCRIPTION
Nice to keep SIG-specific questions out of the bigger project channels.


